### PR TITLE
Project meta

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--
 If this is a pull request for a new release, please use the release template:
-   https://github.com/asfadmin/hyp3-lib/compare/master...develop?template=release.md
+   https://github.com/ASFHyP3/hyp3-lib/compare/master...develop?template=release.md
  
 NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
 changes which you'd like reviewed. Do not open a pull request to update a feature or personal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
           ALLOW_TAG_PREFIX: "true"
-          RELEASE_NAME_PREFIX: HYp3-lib
+          RELEASE_NAME_PREFIX: HyP3-lib
 
       - name: Attempt fast-forward develop from master
         run: |
@@ -40,4 +40,5 @@ jobs:
           pr_assignee: ${{ github.actor }}
           pr_label: tools-bot
           pr_draft: false
+          pr_allow_empty: true
           github_token: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           query: .github/queries/asssociated-pr.query.yml
           outputFile: pr.json
-          owner: asfadmin
+          owner: ASFHyP3
           name: hyp3-lib
           sha: ${{ github.sha }}
 
@@ -79,7 +79,7 @@ jobs:
         with:
           query: .github/queries/pr-labels.query.yml
           outputFile: labels.json
-          owner: asfadmin
+          owner: ASFHyP3
           name: hyp3-lib
 
       - name: Upload a Build Artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0](https://github.com/asfadmin/hyp3-lib/compare/v1.2.3...v1.3.0)
+## [1.3.0](https://github.com/ASFHyP3/hyp3-lib/compare/v1.2.3...v1.3.0)
 
 ### Changed:
 * Requires `pyproj>=2`
@@ -33,7 +33,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Coordinate transformations in `get_dem` now utilize the `pyproj>=2` syntax 
   instead of the depreciated and broken `pyproj<2` syntax
 
-## [1.2.3](https://github.com/asfadmin/hyp3-lib/compare/v1.2.2...v1.2.3)
+## [1.2.3](https://github.com/ASFHyP3/hyp3-lib/compare/v1.2.2...v1.2.3)
 
 ### Fixed:
 * `get_dem.py` will raise an exception if it cannot determine the NoData value
@@ -42,7 +42,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed:
 * `get_dem.py` will determine the correct NoData value for `SRTMGL3` DEMs
   
-## [1.2.2](https://github.com/asfadmin/hyp3-lib/compare/v1.2.1...v1.2.2)
+## [1.2.2](https://github.com/ASFHyP3/hyp3-lib/compare/v1.2.1...v1.2.2)
 
 ### Fixed:
 * `rtc2color.py` was applying the cleanup threshold differently to amplitude and
@@ -54,7 +54,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   type. Similar memory optimizations have been achieved by refactoring and
   leveraging numpy, with an added benefit of a 6x speedup.
 
-## [1.2.1](https://github.com/asfadmin/hyp3-lib/compare/v1.2.0...v1.2.1)
+## [1.2.1](https://github.com/ASFHyP3/hyp3-lib/compare/v1.2.0...v1.2.1)
 
 ### Added:
 * `DemError`, `ExecuteError`, and `GeometryError` (subclasses of the generic `Exception`) for 
@@ -70,20 +70,20 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   error handling
 * `get_asf.py` will not fail silently anymore.
 
-## [1.2.0](https://github.com/asfadmin/hyp3-lib/compare/v1.1.0...v1.2.0)
+## [1.2.0](https://github.com/ASFHyP3/hyp3-lib/compare/v1.1.0...v1.2.0)
 
 ### Added
  * `metadata.add_esa_citation` to add a `ESA_citation.txt` file to a directory
  * `exceptions.GranuleError` for raising issues with granules
 
-## [1.1.0](https://github.com/asfadmin/hyp3-lib/compare/v1.0.0...v1.1.0)
+## [1.1.0](https://github.com/ASFHyP3/hyp3-lib/compare/v1.0.0...v1.1.0)
 
 ### Added
 * `GC_map_mod` bash script, which is used by a few science codes (this has been translated to bash from tcsh)
 * `hyp3lib.system` module for getting system information needed by the science codes
   * includes a `gamma_version` function which will attempt to determine and validate the GAMMA software version
 
-## [1.0.0](https://github.com/asfadmin/hyp3-lib/compare/v0.8.1...v1.0.0)
+## [1.0.0](https://github.com/ASFHyP3/hyp3-lib/compare/v0.8.1...v1.0.0)
 
 This is a significant refactor of `hyp3-lib` into a `pip` installable package called `hyp3lib`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.3.0](https://github.com/asfadmin/hyp3-lib/compare/v1.2.3...v1.3.0)
+## [1.3.0](https://github.com/asfadmin/hyp3-lib/compare/v1.2.3...v1.3.0)
 
 ### Changed:
 * Requires `pyproj>=2`
@@ -33,7 +33,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Coordinate transformations in `get_dem` now utilize the `pyproj>=2` syntax 
   instead of the depreciated and broken `pyproj<2` syntax
 
-## [v1.2.3](https://github.com/asfadmin/hyp3-lib/compare/v1.2.2...v1.2.3)
+## [1.2.3](https://github.com/asfadmin/hyp3-lib/compare/v1.2.2...v1.2.3)
 
 ### Fixed:
 * `get_dem.py` will raise an exception if it cannot determine the NoData value
@@ -42,7 +42,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed:
 * `get_dem.py` will determine the correct NoData value for `SRTMGL3` DEMs
   
-## [v1.2.2](https://github.com/asfadmin/hyp3-lib/compare/v1.2.1...v1.2.2)
+## [1.2.2](https://github.com/asfadmin/hyp3-lib/compare/v1.2.1...v1.2.2)
 
 ### Fixed:
 * `rtc2color.py` was applying the cleanup threshold differently to amplitude and
@@ -54,7 +54,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   type. Similar memory optimizations have been achieved by refactoring and
   leveraging numpy, with an added benefit of a 6x speedup.
 
-## [v1.2.1](https://github.com/asfadmin/hyp3-lib/compare/v1.2.0...v1.2.1)
+## [1.2.1](https://github.com/asfadmin/hyp3-lib/compare/v1.2.0...v1.2.1)
 
 ### Added:
 * `DemError`, `ExecuteError`, and `GeometryError` (subclasses of the generic `Exception`) for 
@@ -70,20 +70,20 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   error handling
 * `get_asf.py` will not fail silently anymore.
 
-## [v1.2.0](https://github.com/asfadmin/hyp3-lib/compare/v1.1.0...v1.2.0)
+## [1.2.0](https://github.com/asfadmin/hyp3-lib/compare/v1.1.0...v1.2.0)
 
 ### Added
  * `metadata.add_esa_citation` to add a `ESA_citation.txt` file to a directory
  * `exceptions.GranuleError` for raising issues with granules
 
-## [v1.1.0](https://github.com/asfadmin/hyp3-lib/compare/v1.0.0...v1.1.0)
+## [1.1.0](https://github.com/asfadmin/hyp3-lib/compare/v1.0.0...v1.1.0)
 
 ### Added
 * `GC_map_mod` bash script, which is used by a few science codes (this has been translated to bash from tcsh)
 * `hyp3lib.system` module for getting system information needed by the science codes
   * includes a `gamma_version` function which will attempt to determine and validate the GAMMA software version
 
-## [v1.0.0](https://github.com/asfadmin/hyp3-lib/compare/v0.8.1...v1.0.0)
+## [1.0.0](https://github.com/asfadmin/hyp3-lib/compare/v0.8.1...v1.0.0)
 
 This is a significant refactor of `hyp3-lib` into a `pip` installable package called `hyp3lib`.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # HyP3-lib
 
-Common library for HyP3 plugins
+## Common library for HyP3 plugins
+
+

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description=long_desc,
     long_description_content_type='text/markdown',
 
-    url='https://github.com/asfadmin/hyp3-lib',
+    url='https://github.com/ASFHyP3/hyp3-lib',
 
     author='ASF APD/Tools Team',
     author_email='uaf-asf-apd@alaska.edu',


### PR DESCRIPTION
* Fix the release workflow to have the correct prefix name, allow empty prs (for failed merge-backs)  
* Fix `CHANGELOG.md` to not have the `v` version prefix (version prefix is okay in `git tags` when writing the release, but disallowed by the regex when grabbing the changes from the changelog)
* Change all references of `asfadmin` github org to new `ASFHyP3` org