### PR TITLE
Allow upfront downloading of orbit files

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Pytest in conda environment
         shell: bash -l {0}
         run: |
-          python -m pip install .
+          python -m pip install .[develop]
           pytest --cov=hyp3lib
 
       - name: Safety analysis of conda environment

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -26,6 +26,7 @@ dependencies:
   - scipy
   - six
   - statsmodels
+  - urllib3
   - pip:
     # for packaging and testing
     - s3pypi

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -22,6 +22,7 @@ dependencies:
   - pillow
   - proj>=2
   - pyshp
+  - responses
   - requests
   - scipy
   - six

--- a/hyp3lib/__init__.py
+++ b/hyp3lib/__init__.py
@@ -10,6 +10,7 @@ from hyp3lib.exceptions import (
     ExecuteError,
     GeometryError,
     GranuleError,
+    OrbitDownloadError,
 )
 
 try:
@@ -28,4 +29,5 @@ __all__ = [
     'ExecuteError',
     'GeometryError',
     'GranuleError',
+    'OrbitDownloadError',
 ]

--- a/hyp3lib/exceptions.py
+++ b/hyp3lib/exceptions.py
@@ -15,3 +15,7 @@ class GeometryError(Exception):
 
 class GranuleError(Exception):
     """Error to be raised for incompatible or missing granules"""
+
+
+class OrbitDownloadError(Exception):
+    """Error to be raised when unable to fetch an orbit file"""

--- a/hyp3lib/fetch.py
+++ b/hyp3lib/fetch.py
@@ -23,7 +23,10 @@ def download_file(url: str, directory: str = '', chunk_size=None, retries=2, bac
     """
     logging.info(f'Downloading {url}')
 
-    download_path = os.path.join(directory, url.split("/")[-1])
+    try:
+        download_path = os.path.join(directory, url.split("/")[-1])
+    except AttributeError:
+        raise requests.exceptions.InvalidURL(f'Invalid URL provided: {url}')
 
     session = requests.Session()
     retry_strategy = Retry(

--- a/hyp3lib/fetch.py
+++ b/hyp3lib/fetch.py
@@ -1,0 +1,21 @@
+"""Utilities for fetching things from external endpoints"""
+
+import logging
+import os
+import requests
+
+
+# TODO:? Max retries, verify, timeout
+def download_file(url, directory=None, headers=None, chunk_size=None):
+    logging.info(f'Downloading {url}')
+    # TODO: works?
+    local_filename = os.path.join(directory, url.split("/")[-1])
+    with requests.get(url, headers=headers, stream=True) as r:
+        if r.status_code == 401:
+            logging.error("Invalid username or password")
+        r.raise_for_status()
+        with open(local_filename, "wb") as f:
+            for chunk in r.iter_content(chunk_size=chunk_size):
+                if chunk:
+                    f.write(chunk)
+    return local_filename

--- a/hyp3lib/fetch.py
+++ b/hyp3lib/fetch.py
@@ -2,17 +2,28 @@
 
 import logging
 import os
+
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 
-# TODO:? Max retries, verify, timeout
-def download_file(url, directory=None, headers=None, chunk_size=None):
+def download_file(url, directory=None, headers=None, chunk_size=None, retries=3, backoff_factor=10):
     logging.info(f'Downloading {url}')
-    # TODO: works?
+
     local_filename = os.path.join(directory, url.split("/")[-1])
+
+    session = requests.Session()
+    retry = Retry(
+        total=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=[429, 500, 503, 504],
+    )
+
+    session.mount('https://', HTTPAdapter(max_retries=retry))
+    session.mount('http://', HTTPAdapter(max_retries=retry))
+
     with requests.get(url, headers=headers, stream=True) as r:
-        if r.status_code == 401:
-            logging.error("Invalid username or password")
         r.raise_for_status()
         with open(local_filename, "wb") as f:
             for chunk in r.iter_content(chunk_size=chunk_size):

--- a/hyp3lib/fetch.py
+++ b/hyp3lib/fetch.py
@@ -8,10 +8,23 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 
-def download_file(url, directory=None, headers=None, chunk_size=None, retries=3, backoff_factor=10):
+def download_file(url: str, directory: str = '.', headers=None, chunk_size=None, retries=3, backoff_factor=10):
+    """Download a file
+
+    Args:
+        url: URL of the file to download
+        directory: Directory location to place files into
+        headers: Dictionary of headers to add to the the download request
+        chunk_size: Size to chunk the download into
+        retries: Number of retry's to attempt
+        backoff_factor: Factor for calculating time between retries
+
+    Returns:
+        download_path: The path to the downloaded file
+    """
     logging.info(f'Downloading {url}')
 
-    local_filename = os.path.join(directory, url.split("/")[-1])
+    download_path = os.path.join(directory, url.split("/")[-1])
 
     session = requests.Session()
     retry = Retry(
@@ -25,8 +38,8 @@ def download_file(url, directory=None, headers=None, chunk_size=None, retries=3,
 
     with requests.get(url, headers=headers, stream=True) as r:
         r.raise_for_status()
-        with open(local_filename, "wb") as f:
+        with open(download_path, "wb") as f:
             for chunk in r.iter_content(chunk_size=chunk_size):
                 if chunk:
                     f.write(chunk)
-    return local_filename
+    return download_path

--- a/hyp3lib/fetch.py
+++ b/hyp3lib/fetch.py
@@ -8,13 +8,12 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 
-def download_file(url: str, directory: str = '.', headers=None, chunk_size=None, retries=3, backoff_factor=10):
+def download_file(url: str, directory: str = '', chunk_size=None, retries=2, backoff_factor=1):
     """Download a file
 
     Args:
         url: URL of the file to download
         directory: Directory location to place files into
-        headers: Dictionary of headers to add to the the download request
         chunk_size: Size to chunk the download into
         retries: Number of retry's to attempt
         backoff_factor: Factor for calculating time between retries
@@ -27,19 +26,19 @@ def download_file(url: str, directory: str = '.', headers=None, chunk_size=None,
     download_path = os.path.join(directory, url.split("/")[-1])
 
     session = requests.Session()
-    retry = Retry(
+    retry_strategy = Retry(
         total=retries,
         backoff_factor=backoff_factor,
         status_forcelist=[429, 500, 503, 504],
     )
 
-    session.mount('https://', HTTPAdapter(max_retries=retry))
-    session.mount('http://', HTTPAdapter(max_retries=retry))
+    session.mount('https://', HTTPAdapter(max_retries=retry_strategy))
+    session.mount('http://', HTTPAdapter(max_retries=retry_strategy))
 
-    with requests.get(url, headers=headers, stream=True) as r:
-        r.raise_for_status()
+    with session.get(url, stream=True) as s:
+        s.raise_for_status()
         with open(download_path, "wb") as f:
-            for chunk in r.iter_content(chunk_size=chunk_size):
+            for chunk in s.iter_content(chunk_size=chunk_size):
                 if chunk:
                     f.write(chunk)
     return download_path

--- a/hyp3lib/get_orb.py
+++ b/hyp3lib/get_orb.py
@@ -100,7 +100,7 @@ def get_orbit_url(granule: str, orbit_type: str = 'AUX_POEORB', provider: str = 
         raise OrbitDownloadError(f'Unknown orbit file provider {provider}')
 
 
-def _download_and_verify_orbit(url: str, directory: str = None):
+def _download_and_verify_orbit(url: str, directory: str = '.'):
     orbit_file = download_file(url, directory=directory, chunk_size=5242880)
     try:
         verify_opod(orbit_file)
@@ -111,7 +111,7 @@ def _download_and_verify_orbit(url: str, directory: str = None):
     return orbit_file
 
 
-def downloadSentinelOrbitFile(granule: str, directory: str = None, providers=('ESA', 'ASF')):
+def downloadSentinelOrbitFile(granule: str, directory: str = '.', providers=('ESA', 'ASF')):
     """Download a Sentinel-1 Orbit file
 
     Args:
@@ -147,14 +147,13 @@ def main():
     parser = argparse.ArgumentParser(
         prog=os.path.basename(__file__),
         description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument('safe_files', help='Sentinel-1 SAFE file name(s)', nargs="*")
-    parser.add_argument('-p', '--provider', choices=['ASF', 'ESA'], help='Name of orbit file provider organization')
-    parser.add_argument('-d', '--directory', help='Download files to this directory')
+    parser.add_argument('-p', '--provider', choices=['ESA', 'ASF'], nargs='*', default=['ESA', 'ASF'],
+                        help="Name(s) of the orbit file providers' organization, in order of preference")
+    parser.add_argument('-d', '--directory', default=os.getcwd(), help='Download files to this directory')
     args = parser.parse_args()
-
-    if args.provider is None:
-        args.provider = ('ASF', 'ESA')
 
     out = logging.StreamHandler(stream=sys.stdout)
     out.addFilter(lambda record: record.levelno <= logging.INFO)

--- a/hyp3lib/get_orb.py
+++ b/hyp3lib/get_orb.py
@@ -32,26 +32,22 @@ def _get_asf_orbit_url(orbit_type, platform, timestamp):
     response = session.get(search_url)
     response.raise_for_status()
     tree = html.fromstring(response.content)
-    file_list = [file for file in tree.xpath('//a[@href]//@href') if file.endswith('.EOF')]
+    file_list = [file for file in tree.xpath('//a[@href]//@href')
+                 if file.startswith(platform) and file.endswith('.EOF')]
 
     d1 = 0
     best = None
-    for item in file_list:
-        if 'S1' in item:
-            item = item.replace(' ', '')
-            item1 = item
-            this_plat = item[0:3]
-            item = item.replace('T', '')
-            item = item.replace('V', '')
-            t = re.split('_', item)
-            if len(t) > 7:
-                start = t[6]
-                end = t[7].replace('.EOF', '')
-                if start < timestamp < end and platform == this_plat:
-                    d = ((int(timestamp) - int(start)) + (int(end) - int(timestamp))) / 2
-                    if d > d1:
-                        best = item1.replace(' ', '')
-                        d1 = d
+    for file in file_list:
+        file = file.strip()
+        t = re.split('_', file.replace('T', '').replace('V', ''))
+        if len(t) > 7:
+            start = t[6]
+            end = t[7].replace('.EOF', '')
+            if start < timestamp < end:
+                d = ((int(timestamp) - int(start)) + (int(end) - int(timestamp))) / 2
+                if d > d1:
+                    best = file
+                    d1 = d
     return search_url + best
 
 

--- a/hyp3lib/get_orb.py
+++ b/hyp3lib/get_orb.py
@@ -2,20 +2,19 @@
 
 from __future__ import print_function, absolute_import, division, unicode_literals
 
-import re
-from lxml import html
-import os
-from datetime import datetime, timedelta
 import argparse
-from hyp3lib.verify_opod import verify_opod
-import requests
 import json
+import os
+import re
+from datetime import datetime, timedelta
+
+import requests
+from lxml import html
 from requests.adapters import HTTPAdapter
 from six.moves.urllib.parse import urlparse
 
-
-class FileException(Exception):
-  """Could not download orbit file"""
+from hyp3lib import OrbitDownloadError
+from hyp3lib.verify_opod import verify_opod
 
 
 def getPageContentsESA(url, verify):
@@ -31,10 +30,11 @@ def getPageContentsESA(url, verify):
         print(results['results'][0]['physical_name'])
         fileName = results['results'][0]['physical_name']
         url = results['results'][0]['remote_url']
-        return(fileName,url)
+        return (fileName, url)
     else:
         print("WARNING: No results returned from ESA query")
-    return(None,None)
+    return (None, None)
+
 
 def getPageContents(url, verify):
     hostname = urlparse(url).hostname
@@ -49,6 +49,7 @@ def getPageContents(url, verify):
             ret.append(item)
     return ret
 
+
 def dateStr2dateTime(string):
     year = string[0:4]
     month = string[4:6]
@@ -56,27 +57,28 @@ def dateStr2dateTime(string):
     hour = string[8:10]
     minute = string[10:12]
     second = string[12:14]
-    outTime = datetime.strptime("{}-{}-{}T{}:{}:{}".format(year,month,day,hour,minute,second),'%Y-%m-%dT%H:%M:%S')
-    return(outTime)
+    outTime = datetime.strptime("{}-{}-{}T{}:{}:{}".format(year, month, day, hour, minute, second), '%Y-%m-%dT%H:%M:%S')
+    return (outTime)
 
-def findOrbFile(plat,tm,lst):
+
+def findOrbFile(plat, tm, lst):
     d1 = 0
     best = ''
     for item in lst:
         if 'S1' in item:
-            item = item.replace(' ','')
+            item = item.replace(' ', '')
             item1 = item
-            this_plat=item[0:3]
-            item=item.replace('T','')
-            item=item.replace('V','')
-            t = re.split('_',item)
+            this_plat = item[0:3]
+            item = item.replace('T', '')
+            item = item.replace('V', '')
+            t = re.split('_', item)
             if len(t) > 7:
                 start = t[6]
-                end = t[7].replace('.EOF','')
+                end = t[7].replace('.EOF', '')
                 if start < tm and end > tm and plat == this_plat:
-                    d = ((int(tm)-int(start))+(int(end)-int(tm)))/2
-                    if d>d1:
-                        best = item1.replace(' ','')
+                    d = ((int(tm) - int(start)) + (int(end) - int(tm))) / 2
+                    if d > d1:
+                        best = item1.replace(' ', '')
                         d1 = d
     return best
 
@@ -88,108 +90,110 @@ def getOrbFile(s1Granule):
 
     # get rid of ending "/" 
     if Granule.endswith("/"):
-        Granule = Granule[0:len(Granule)-1]
+        Granule = Granule[0:len(Granule) - 1]
 
-    t = re.split('_+',Granule)
-    st = t[4].replace('T','')
+    t = re.split('_+', Granule)
+    st = t[4].replace('T', '')
     url = url1
     files = getPageContents(url, True)
     plat = Granule[0:3]
-    orb = findOrbFile(plat,st,files)
+    orb = findOrbFile(plat, st, files)
     if orb == '':
         url = url2
         files = getPageContents(url, True)
-        orb = findOrbFile(plat,st,files)
+        orb = findOrbFile(plat, st, files)
     if orb == '':
         error = 'Could not find orbit file on ASF website'
-        raise FileException(error)
-    return url+orb,orb
+        raise OrbitDownloadError(error)
+    return url + orb, orb
 
 
 def getOrbitFileESA(dataFile):
-  precise    = 'https://qc.sentinel1.eo.esa.int/api/v1/?product_type=AUX_POEORB&ordering=-creation_date&page_size=1&'
-  restituted = 'https://qc.sentinel1.eo.esa.int/api/v1/?product_type=AUX_RESORB&ordering=-creation_date&page_size=1&'
-  sec60 = timedelta(seconds=60)
-  plat = dataFile[0:3]
-  precise += 'sentinel1__mission={}&'.format(plat)
-  restituted += 'sentinel1__mission={}&'.format(plat)
-  t = re.split('_+',dataFile)
-  st = t[4].replace('T','')
-  et = t[5].replace('T','')
+    precise = 'https://qc.sentinel1.eo.esa.int/api/v1/?product_type=AUX_POEORB&ordering=-creation_date&page_size=1&'
+    restituted = 'https://qc.sentinel1.eo.esa.int/api/v1/?product_type=AUX_RESORB&ordering=-creation_date&page_size=1&'
+    sec60 = timedelta(seconds=60)
+    plat = dataFile[0:3]
+    precise += 'sentinel1__mission={}&'.format(plat)
+    restituted += 'sentinel1__mission={}&'.format(plat)
+    t = re.split('_+', dataFile)
+    st = t[4].replace('T', '')
+    et = t[5].replace('T', '')
 
-  start_time = dateStr2dateTime(st)
-  end_time = dateStr2dateTime(et)
+    start_time = dateStr2dateTime(st)
+    end_time = dateStr2dateTime(et)
 
-  start_time = start_time - sec60
-  end_time = end_time + sec60
+    start_time = start_time - sec60
+    end_time = end_time + sec60
 
-  q = precise+'validity_stop__gt='+start_time.strftime('%Y-%m-%dT%H:%M:%S')+'&validity_start__lt='+end_time.strftime('%Y-%m-%dT%H:%M:%S')
-  orbitFile,url = getPageContentsESA(q, False)
-  if url:
-    print("Using url {}".format(url))
-  else:
-    print("Unable to find POEORB - Looking for RESORB")
-    q=restituted+'validity_stop__gt='+start_time.strftime('%Y-%m-%dT%H:%M:%S')+'&validity_start__lt='+end_time.strftime('%Y-%m-%dT%H:%M:%S')
-    orbitFile,url = getPageContentsESA(q, False)
+    q = precise + 'validity_stop__gt=' + start_time.strftime(
+        '%Y-%m-%dT%H:%M:%S') + '&validity_start__lt=' + end_time.strftime('%Y-%m-%dT%H:%M:%S')
+    orbitFile, url = getPageContentsESA(q, False)
     if url:
-      print("Using url {}".format(url))
+        print("Using url {}".format(url))
     else:
-      error = 'Could not find orbit file on ESA website'
-      raise FileException(error)
+        print("Unable to find POEORB - Looking for RESORB")
+        q = restituted + 'validity_stop__gt=' + start_time.strftime(
+            '%Y-%m-%dT%H:%M:%S') + '&validity_start__lt=' + end_time.strftime('%Y-%m-%dT%H:%M:%S')
+        orbitFile, url = getPageContentsESA(q, False)
+        if url:
+            print("Using url {}".format(url))
+        else:
+            error = 'Could not find orbit file on ESA website'
+            raise OrbitDownloadError(error)
 
-  return url, orbitFile
+    return url, orbitFile
 
 
-def fetchOrbitFile(urlOrb,stateVecFile,verify):
-  hostname = urlparse(urlOrb).hostname
-  session = requests.Session()
-  session.mount(hostname, HTTPAdapter(max_retries=10))
-  request = session.get(urlOrb, timeout=60, verify=verify)
-  f = open(stateVecFile, 'w')
-  f.write(request.text)
-  f.close()
+def fetchOrbitFile(urlOrb, stateVecFile, verify):
+    hostname = urlparse(urlOrb).hostname
+    session = requests.Session()
+    session.mount(hostname, HTTPAdapter(max_retries=10))
+    request = session.get(urlOrb, timeout=60, verify=verify)
+    f = open(stateVecFile, 'w')
+    f.write(request.text)
+    f.close()
 
 
 def downloadSentinelOrbitFileProvider(granule, provider, directory):
-  if provider.upper() == 'ASF':
-    urlOrb, fileNameOrb = getOrbFile(granule)
-    verify = True
-  elif provider.upper() == 'ESA':
-    urlOrb, fileNameOrb = getOrbitFileESA(granule)
-    verify = False
+    if provider.upper() == 'ASF':
+        urlOrb, fileNameOrb = getOrbFile(granule)
+        verify = True
+    elif provider.upper() == 'ESA':
+        urlOrb, fileNameOrb = getOrbitFileESA(granule)
+        verify = False
 
-  if directory:
-    stateVecFile = os.path.join(directory, fileNameOrb)
-  else:
-    stateVecFile = fileNameOrb
-
-  if not os.path.isfile(stateVecFile):
-    if len(stateVecFile) > 0:
-      fetchOrbitFile(urlOrb,stateVecFile,verify)
-      return stateVecFile
+    if directory:
+        stateVecFile = os.path.join(directory, fileNameOrb)
     else:
-      return None
-  else:
-    print("Using existing orbit file; provider unknown")
-    return stateVecFile
+        stateVecFile = fileNameOrb
+
+    if not os.path.isfile(stateVecFile):
+        if len(stateVecFile) > 0:
+            fetchOrbitFile(urlOrb, stateVecFile, verify)
+            return stateVecFile
+        else:
+            return None
+    else:
+        print("Using existing orbit file; provider unknown")
+        return stateVecFile
 
 
-def downloadSentinelOrbitFile(granule,directory=None):
+def downloadSentinelOrbitFile(granule, directory=None):
     try:
-        stateVecFile=downloadSentinelOrbitFileProvider(granule,'ASF',directory)
+        stateVecFile = downloadSentinelOrbitFileProvider(granule, 'ASF', directory)
         provider = "ASF"
         print("Found state vector file at ASF")
     except:
         print("Unable to find statevector at ASF; trying ESA")
         try:
-            stateVecFile = downloadSentinelOrbitFileProvider(granule,'ESA',directory) 
+            stateVecFile = downloadSentinelOrbitFileProvider(granule, 'ESA', directory)
             if stateVecFile:
                 provider = "ESA"
                 print("Found state vector file at ESA")
         except:
             print("Unable to find requested state vector file")
             provider = "NA"
-            return None,provider
+            return None, provider
     verify_opod(stateVecFile)
     return stateVecFile, provider
 

--- a/hyp3lib/get_orb.py
+++ b/hyp3lib/get_orb.py
@@ -92,8 +92,7 @@ def get_orbit_url(granule: str, orbit_type: str = 'AUX_POEORB', provider: str = 
         orbit_url = _get_asf_orbit_url(orbit_type.lower(), platform, time_stamps[0].replace('T', ''))
         return orbit_url
 
-    else:
-        raise OrbitDownloadError(f'Unknown orbit file provider {provider}')
+    raise OrbitDownloadError(f'Unknown orbit file provider {provider}')
 
 
 def _download_and_verify_orbit(url: str, directory: str = '.'):

--- a/hyp3lib/get_orb.py
+++ b/hyp3lib/get_orb.py
@@ -121,18 +121,26 @@ def downloadSentinelOrbitFile(granule: str, directory: str = '.', providers=('ES
 
     """
     for provider in providers:
-        url = get_orbit_url(granule, 'AUX_POEORB', provider=provider)
-        if url is not None:
-            orbit_file = _download_and_verify_orbit(url, directory=directory)
-            if orbit_file:
-                return orbit_file, provider
+        try:
+            url = get_orbit_url(granule, 'AUX_POEORB', provider=provider)
+            if url is not None:
+                orbit_file = _download_and_verify_orbit(url, directory=directory)
+                if orbit_file:
+                    return orbit_file, provider
+        except (requests.RequestException, OrbitDownloadError) as e:
+            logging.exception('Error encountered fetching orbit file; looking for another', exc_info=e)
+            continue
 
     for provider in providers:
-        url = get_orbit_url(granule, 'AUX_RESORB', provider=provider)
-        if url is not None:
-            orbit_file = _download_and_verify_orbit(url, directory=directory)
-            if orbit_file:
-                return orbit_file, provider
+        try:
+            url = get_orbit_url(granule, 'AUX_RESORB', provider=provider)
+            if url is not None:
+                orbit_file = _download_and_verify_orbit(url, directory=directory)
+                if orbit_file:
+                    return orbit_file, provider
+        except (requests.RequestException, OrbitDownloadError) as e:
+            logging.exception('Error encountered fetching orbit file; looking for another', exc_info=e)
+            continue
 
     raise OrbitDownloadError(f'Unable to find a valid orbit file from providers: {providers}')
 

--- a/hyp3lib/get_orb.py
+++ b/hyp3lib/get_orb.py
@@ -1,10 +1,10 @@
 """Get Sentinel-1 orbit file(s) from ASF or ESA website"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import argparse
+import logging
 import os
 import re
+import sys
 from datetime import datetime, timedelta
 
 import requests
@@ -152,15 +152,20 @@ def main():
     if args.provider is None:
         args.provider = ('ASF', 'ESA')
 
+    out = logging.StreamHandler(stream=sys.stdout)
+    out.addFilter(lambda record: record.levelno <= logging.INFO)
+    err = logging.StreamHandler()
+    err.setLevel(logging.WARNING)
+    logging.basicConfig(format='%(message)s', level=logging.INFO, handlers=(out, err))
+
     for safe in args.safe_files:
         try:
             orbit_file, provided_by = download_sentinel_orbit_file(
                 safe, directory=args.directory, providers=tuple(args.provider)
             )
-            print("Downloaded orbit file {} from {}".format(orbit_file, provided_by))
+            logging.info("Downloaded orbit file {} from {}".format(orbit_file, provided_by))
         except OrbitDownloadError as e:
-            print(f'WARNING: unable to download orbit file for {safe}')
-            print(f'    {e}')
+            logging.warning(f'WARNING: unable to download orbit file for {safe}\n    {e}')
 
 
 if __name__ == "__main__":

--- a/hyp3lib/get_orb.py
+++ b/hyp3lib/get_orb.py
@@ -95,7 +95,7 @@ def get_orbit_url(granule: str, orbit_type: str = 'AUX_POEORB', provider: str = 
     raise OrbitDownloadError(f'Unknown orbit file provider {provider}')
 
 
-def _download_and_verify_orbit(url: str, directory: str = '.'):
+def _download_and_verify_orbit(url: str, directory: str = ''):
     orbit_file = download_file(url, directory=directory, chunk_size=5242880)
     try:
         verify_opod(orbit_file)
@@ -106,7 +106,7 @@ def _download_and_verify_orbit(url: str, directory: str = '.'):
     return orbit_file
 
 
-def downloadSentinelOrbitFile(granule: str, directory: str = '.', providers=('ESA', 'ASF')):
+def downloadSentinelOrbitFile(granule: str, directory: str = '', providers=('ESA', 'ASF')):
     """Download a Sentinel-1 Orbit file
 
     Args:

--- a/hyp3lib/get_orb.py
+++ b/hyp3lib/get_orb.py
@@ -111,7 +111,7 @@ def _download_and_verify_orbit(url: str, directory: str = None):
     return orbit_file
 
 
-def download_sentinel_orbit_file(granule: str, directory: str = None, providers=('ESA', 'ASF')):
+def downloadSentinelOrbitFile(granule: str, directory: str = None, providers=('ESA', 'ASF')):
     """Download a Sentinel-1 Orbit file
 
     Args:
@@ -164,7 +164,7 @@ def main():
 
     for safe in args.safe_files:
         try:
-            orbit_file, provided_by = download_sentinel_orbit_file(
+            orbit_file, provided_by = downloadSentinelOrbitFile(
                 safe, directory=args.directory, providers=tuple(args.provider)
             )
             logging.info("Downloaded orbit file {} from {}".format(orbit_file, provided_by))

--- a/hyp3lib/ingest_S1_granule.py
+++ b/hyp3lib/ingest_S1_granule.py
@@ -10,15 +10,15 @@ from hyp3lib.get_orb import download_sentinel_orbit_file
 from hyp3lib.par_s1_slc_single import par_s1_slc_single
 
 
-def ingest_S1_granule(safe_dir, pol, looks, out_file, orbit_file=None):
-    """
+def ingest_S1_granule(safe_dir: str, pol: str, looks: int, out_file: str, orbit_file: str = None):
+    """Pre-process S1 imagery into GAMMA format
 
     Args:
-        safe_dir:
-        pol:
-        looks:
-        out_file:
-        orbit_file:
+        safe_dir: Sentinel-1 SAFE directory location
+        pol: polarization (e.g., 'vv')
+        looks: the number of looks to take
+        out_file: file name of the output GAMMA formatted imagery
+        orbit_file: Orbit file to use (will download a matching orbit file if None)
     """
     pol = pol.lower()
     granule_type = safe_dir[7:11]
@@ -51,21 +51,16 @@ def ingest_S1_granule(safe_dir, pol, looks, out_file, orbit_file=None):
 
     else:
         #  Ingest SLC data files into gamma format
-        par_s1_slc_single(safe_dir, pol)
+        par_s1_slc_single(safe_dir, pol, orbit_file=orbit_file)
         date = safe_dir[17:25]
-        make_tab_flag = True
-        burst_tab = getBursts(safe_dir, make_tab_flag)
+        burst_tab = getBursts(safe_dir, make_tab_flag=True)
         shutil.copy(burst_tab, date)
 
         # Mosaic the swaths together and copy SLCs over        
         back = os.getcwd()
         os.chdir(date)
-        path = '../'
-        rlooks = looks * 5
-        alooks = looks
-        SLC_copy_S1_fullSW(path, date, 'SLC_TAB', burst_tab, mode=2, raml=rlooks, azml=alooks)
+        SLC_copy_S1_fullSW('../', date, 'SLC_TAB', burst_tab, mode=2, raml=looks * 5, azml=looks)
         os.chdir(back)
 
-        # Rename files
         shutil.move(f'{date}.mli', out_file)
         shutil.move(f'{date}.mli.par', f'{out_file}.par')

--- a/hyp3lib/ingest_S1_granule.py
+++ b/hyp3lib/ingest_S1_granule.py
@@ -6,7 +6,7 @@ from hyp3lib import ExecuteError, OrbitDownloadError
 from hyp3lib.SLC_copy_S1_fullSW import SLC_copy_S1_fullSW
 from hyp3lib.execute import execute
 from hyp3lib.getBursts import getBursts
-from hyp3lib.get_orb import downloadSentinelOrbitFile
+from hyp3lib.get_orb import download_sentinel_orbit_file
 from hyp3lib.par_s1_slc_single import par_s1_slc_single
 
 
@@ -33,7 +33,7 @@ def ingest_S1_granule(safe_dir, pol, looks, out_file, orbit_file=None):
         try:
             if orbit_file is None:
                 logging.info('Trying to get orbit file information from file {}'.format(safe_dir))
-                orbit_file, _ = downloadSentinelOrbitFile(safe_dir)
+                orbit_file, _ = download_sentinel_orbit_file(safe_dir)
             logging.debug('Applying precision orbit information')
             cmd = f'S1_OPOD_vec {pol}.grd.par {orbit_file}'
             execute(cmd, uselogging=True)

--- a/hyp3lib/ingest_S1_granule.py
+++ b/hyp3lib/ingest_S1_granule.py
@@ -21,10 +21,10 @@ def ingest_S1_granule(safe_dir: str, pol: str, looks: int, out_file: str, orbit_
         orbit_file: Orbit file to use (will download a matching orbit file if None)
     """
     pol = pol.lower()
-    granule_type = safe_dir[7:11]
+    granule_type = safe_dir[7:10]
 
     # Ingest the granule into gamma format
-    if "GRD" in granule_type:
+    if granule_type == 'GRD':
         cmd = f'par_S1_GRD {safe_dir}/*/*{pol}*.tiff {safe_dir}/*/*{pol}*.xml {safe_dir}/*/*/calibration-*{pol}*.xml ' \
               f'{safe_dir}/*/*/noise-*{pol}*.xml {pol}.grd.par {pol}.grd'
         execute(cmd, uselogging=True)

--- a/hyp3lib/ingest_S1_granule.py
+++ b/hyp3lib/ingest_S1_granule.py
@@ -1,65 +1,71 @@
-from __future__ import print_function, absolute_import, division, unicode_literals
-
-from hyp3lib.execute import execute
 import logging
+import os
 import shutil
-from hyp3lib.par_s1_slc_single import par_s1_slc_single
+
+from hyp3lib import ExecuteError
 from hyp3lib.SLC_copy_S1_fullSW import SLC_copy_S1_fullSW
+from hyp3lib.execute import execute
 from hyp3lib.getBursts import getBursts
 from hyp3lib.get_orb import downloadSentinelOrbitFile
-import os
+from hyp3lib.par_s1_slc_single import par_s1_slc_single
 
 
-def ingest_S1_granule(inFile,pol,look_fact,outFile):
+def ingest_S1_granule(safe_dir, pol, looks, out_file, orbit_file=None):
+    """
 
+    Args:
+        safe_dir:
+        pol:
+        looks:
+        out_file:
+        orbit_file:
+    """
     pol = pol.lower()
-    inputType = inFile[7:11]
-    grd = "{}.grd".format(pol)
-    
+    granule_type = safe_dir[7:11]
+
     # Ingest the granule into gamma format
-    if "GRD" in inputType:
-        cmd = "par_S1_GRD {inf}/*/*{pol}*.tiff {inf}/*/*{pol}*.xml {inf}/*/*/calibration-*{pol}*.xml " \
-              "{inf}/*/*/noise-*{pol}*.xml {grd}.par {grd}".format(inf=inFile,pol=pol,grd=grd)
-        execute(cmd,uselogging=True)
+    if "GRD" in granule_type:
+        cmd = f'par_S1_GRD {safe_dir}/*/*{pol}*.tiff {safe_dir}/*/*{pol}*.xml {safe_dir}/*/*/calibration-*{pol}*.xml ' \
+              f'{safe_dir}/*/*/noise-*{pol}*.xml {pol}.grd.par {pol}.grd'
+        execute(cmd, uselogging=True)
 
         # Fetch precision state vectors
 
         try:
-            logging.info("Trying to get orbit file information from file {}".format(inFile))
-            orbfile,tmp = downloadSentinelOrbitFile(inFile)
-            logging.debug("Applying precision orbit information")
-            cmd = "S1_OPOD_vec {grd}.par {eof}".format(grd=grd,eof=orbfile)
-            execute(cmd,uselogging=True)
-        except:
-            logging.warning("Unable to fetch precision state vectors... continuing")
-        
+            if orbit_file is None:
+                logging.info('Trying to get orbit file information from file {}'.format(safe_dir))
+                orbit_file, _ = downloadSentinelOrbitFile(safe_dir)
+            logging.debug('Applying precision orbit information')
+            cmd = f'S1_OPOD_vec {pol}.grd.par {orbit_file}'
+            execute(cmd, uselogging=True)
+        except ExecuteError:  # TODO orbit download error...
+            logging.warning('Unable to fetch precision state vectors... continuing')
+
         # Multi-look the image
-        if look_fact > 1.0:
-            cmd = "multi_look_MLI {grd} {grd}.par {outFile} {outFile}.par {lks} {lks}".format(grd=grd,outFile=outFile,lks=look_fact)
-            execute(cmd,uselogging=True)
+        if looks > 1.0:
+            cmd = f'multi_look_MLI {pol}.grd {pol}.grd.par {out_file} {out_file}.par {looks} {looks}'
+            execute(cmd, uselogging=True)
         else:
-            shutil.copy(grd,outFile)
-            shutil.copy("{}.par".format(grd),"{}.par".format(outFile))
+            shutil.copy(f'{pol}.grd', out_file)
+            shutil.copy(f'{pol}.grd.par', f'{out_file}.par')
 
     else:
         #  Ingest SLC data files into gamma format
-        par_s1_slc_single(inFile,pol)
-        date = inFile[17:25]
+        par_s1_slc_single(safe_dir, pol)
+        date = safe_dir[17:25]
         make_tab_flag = True
-        burst_tab = getBursts(inFile,make_tab_flag)
-        shutil.copy(burst_tab,date)
+        burst_tab = getBursts(safe_dir, make_tab_flag)
+        shutil.copy(burst_tab, date)
 
         # Mosaic the swaths together and copy SLCs over        
         back = os.getcwd()
-        os.chdir(date) 
-        path = "../"
-        rlooks = look_fact*5
-        alooks = look_fact 
-        SLC_copy_S1_fullSW(path,date,"SLC_TAB",burst_tab,mode=2,raml=rlooks,azml=alooks)
+        os.chdir(date)
+        path = '../'
+        rlooks = looks * 5
+        alooks = looks
+        SLC_copy_S1_fullSW(path, date, 'SLC_TAB', burst_tab, mode=2, raml=rlooks, azml=alooks)
         os.chdir(back)
- 
+
         # Rename files
-        name = "{}.mli".format(date)
-        shutil.move(name,outFile)
-        name = "{}.mli.par".format(date)
-        shutil.move(name,"{}.par".format(outFile))
+        shutil.move(f'{date}.mli', out_file)
+        shutil.move(f'{date}.mli.par', f'{out_file}.par')

--- a/hyp3lib/ingest_S1_granule.py
+++ b/hyp3lib/ingest_S1_granule.py
@@ -6,7 +6,7 @@ from hyp3lib import ExecuteError, OrbitDownloadError
 from hyp3lib.SLC_copy_S1_fullSW import SLC_copy_S1_fullSW
 from hyp3lib.execute import execute
 from hyp3lib.getBursts import getBursts
-from hyp3lib.get_orb import download_sentinel_orbit_file
+from hyp3lib.get_orb import downloadSentinelOrbitFile
 from hyp3lib.par_s1_slc_single import par_s1_slc_single
 
 
@@ -33,7 +33,7 @@ def ingest_S1_granule(safe_dir: str, pol: str, looks: int, out_file: str, orbit_
         try:
             if orbit_file is None:
                 logging.info('Trying to get orbit file information from file {}'.format(safe_dir))
-                orbit_file, _ = download_sentinel_orbit_file(safe_dir)
+                orbit_file, _ = downloadSentinelOrbitFile(safe_dir)
             logging.debug('Applying precision orbit information')
             cmd = f'S1_OPOD_vec {pol}.grd.par {orbit_file}'
             execute(cmd, uselogging=True)

--- a/hyp3lib/par_s1_slc_single.py
+++ b/hyp3lib/par_s1_slc_single.py
@@ -1,9 +1,6 @@
 """Pre-process S1 SLC imagery into gamma format SLCs"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import logging
-import argparse
 from hyp3lib.execute import execute
 from hyp3lib.getParameter import getParameter
 import os
@@ -113,28 +110,3 @@ def par_s1_slc_single(myfile, pol=None):
     width = getParameter("{}_003.slc.par".format(acqdate),"range_samples")
     execute("rasSLC {}_003.slc {} 1 0 50 10".format(acqdate,width))
     os.chdir(wrk)
-
-
-def main():
-    """Main entrypoint"""
-
-    parser = argparse.ArgumentParser(
-        prog=os.path.basename(__file__),
-        description=__doc__,
-    )
-    parser.add_argument('infile', help='input SAFE file name')
-    parser.add_argument('-p', '--pol', default='vv', help='name of polarization to process (default vv)')
-    args = parser.parse_args()
-
-    logFile = "par_s1_slc_single_log.txt"
-    logging.basicConfig(filename=logFile, format='%(asctime)s - %(levelname)s - %(message)s',
-                        datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.DEBUG)
-    logging.getLogger().addHandler(logging.StreamHandler())
-    logging.info("Starting run")
-
-    par_s1_slc_single(args.infile, args.pol)
-
-
-if __name__ == '__main__':
-    main()
-

--- a/hyp3lib/par_s1_slc_single.py
+++ b/hyp3lib/par_s1_slc_single.py
@@ -1,34 +1,37 @@
 """Pre-process S1 SLC imagery into gamma format SLCs"""
 
+import glob
 import logging
+import os
+
+from hyp3lib import ExecuteError, OrbitDownloadError
 from hyp3lib.execute import execute
 from hyp3lib.getParameter import getParameter
-import os
-import glob
-from hyp3lib.get_orb import downloadSentinelOrbitFile
+from hyp3lib.get_orb import download_sentinel_orbit_file
+
 
 #
 # This subroutine assembles the par_S1_SLC gamma commands
 #
-def make_cmd(val,acqdate,path,pol=None):
+def make_cmd(val, acqdate, path, pol=None):
     if pol is None:
         m = glob.glob("measurement/s1*-iw{VAL}*".format(VAL=val))[0]
         n = glob.glob("annotation/s1*-iw{VAL}*".format(VAL=val))[0]
         o = glob.glob("annotation/calibration/calibration-s1*-iw{VAL}*".format(VAL=val))[0]
         p = glob.glob("annotation/calibration/noise-s1*-iw{VAL}*".format(VAL=val))[0]
     else:
-        m = glob.glob("measurement/s1*-iw{VAL}*{POL}*".format(VAL=val,POL=pol))[0]
-        n = glob.glob("annotation/s1*-iw{VAL}*{POL}*".format(VAL=val,POL=pol))[0]
-        o = glob.glob("annotation/calibration/calibration-s1*-iw{VAL}*{POL}*".format(VAL=val,POL=pol))[0]
-        p = glob.glob("annotation/calibration/noise-s1*-iw{VAL}*{POL}*".format(VAL=val,POL=pol))[0]
-    cmd = "par_S1_SLC {m} {n} {o} {p} {path}/{acq}_00{VAL}.slc.par {path}/{acq}_00{VAL}.slc {path}/{acq}_00{VAL}.tops_par".format(acq=acqdate,m=m,n=n,o=o,p=p,VAL=val,path=path) 
+        m = glob.glob("measurement/s1*-iw{VAL}*{POL}*".format(VAL=val, POL=pol))[0]
+        n = glob.glob("annotation/s1*-iw{VAL}*{POL}*".format(VAL=val, POL=pol))[0]
+        o = glob.glob("annotation/calibration/calibration-s1*-iw{VAL}*{POL}*".format(VAL=val, POL=pol))[0]
+        p = glob.glob("annotation/calibration/noise-s1*-iw{VAL}*{POL}*".format(VAL=val, POL=pol))[0]
+    cmd = "par_S1_SLC {m} {n} {o} {p} {path}/{acq}_00{VAL}.slc.par {path}/{acq}_00{VAL}.slc {path}/{acq}_00{VAL}.tops_par".format(
+        acq=acqdate, m=m, n=n, o=o, p=p, VAL=val, path=path)
     return cmd
 
 
-def par_s1_slc_single(myfile, pol=None):
-
+def par_s1_slc_single(myfile, pol=None, orbit_file=None):
     wrk = os.getcwd()
-   
+
     if pol is None:
         pol = 'vv'
 
@@ -37,25 +40,25 @@ def par_s1_slc_single(myfile, pol=None):
     logging.info("Found image type {}".format(mytype))
 
     if "SSH" in mytype or "SSV" in mytype:
-         logging.info("Found single pol file")
-         single_pol = 1
+        logging.info("Found single pol file")
+        single_pol = 1
     elif "SDV" in mytype:
-         logging.info("Found multi-pol file")
-         single_pol = 0
-         if "hv" in pol or "hh" in pol:
-             logging.error("ERROR: no {} polarization exists in a {} file".format(pol,mytype))
-             exit(1)
+        logging.info("Found multi-pol file")
+        single_pol = 0
+        if "hv" in pol or "hh" in pol:
+            logging.error("ERROR: no {} polarization exists in a {} file".format(pol, mytype))
+            exit(1)
     elif "SDH" in mytype:
-         logging.info("Found multi-pol file")
-         single_pol = 0
-         if "vh" in pol or "vv" in pol:
-             logging.error("ERROR: no {} polarization exists in a {} file".format(pol,mytype))
-             exit(1)
+        logging.info("Found multi-pol file")
+        single_pol = 0
+        if "vh" in pol or "vv" in pol:
+            logging.error("ERROR: no {} polarization exists in a {} file".format(pol, mytype))
+            exit(1)
 
-    folder = myfile.replace(".SAFE","")
+    folder = myfile.replace(".SAFE", "")
     datelong = myfile.split("_")[5]
     acqdate = (myfile.split("_")[5].split("T"))[0]
-    path = os.path.join(wrk,acqdate)
+    path = os.path.join(wrk, acqdate)
     if not os.path.exists(path):
         os.mkdir(path)
 
@@ -66,32 +69,35 @@ def par_s1_slc_single(myfile, pol=None):
     os.chdir("{}.SAFE".format(folder))
 
     if (single_pol == 1):
-        cmd = make_cmd(1,acqdate,path)
-        execute(cmd,uselogging=True)
-        cmd = make_cmd(2,acqdate,path)
-        execute(cmd,uselogging=True)
-        cmd = make_cmd(3,acqdate,path)
-        execute(cmd,uselogging=True)
+        cmd = make_cmd(1, acqdate, path)
+        execute(cmd, uselogging=True)
+        cmd = make_cmd(2, acqdate, path)
+        execute(cmd, uselogging=True)
+        cmd = make_cmd(3, acqdate, path)
+        execute(cmd, uselogging=True)
     else:
-        cmd = make_cmd(1,acqdate,path,pol=pol)
-        execute(cmd,uselogging=True)
-        cmd = make_cmd(2,acqdate,path,pol=pol)
-        execute(cmd,uselogging=True)
-        cmd = make_cmd(3,acqdate,path,pol=pol)
-        execute(cmd,uselogging=True)
+        cmd = make_cmd(1, acqdate, path, pol=pol)
+        execute(cmd, uselogging=True)
+        cmd = make_cmd(2, acqdate, path, pol=pol)
+        execute(cmd, uselogging=True)
+        cmd = make_cmd(3, acqdate, path, pol=pol)
+        execute(cmd, uselogging=True)
 
     os.chdir(path)
 
     # Fetch precision state vectors
     try:
-        logging.info("Getting precision orbit information")
-        orb,tmp = downloadSentinelOrbitFile(myfile)
+        if orbit_file is None:
+            logging.info('Trying to get orbit file information from file {}'.format(myfile))
+            orbit_file, _ = download_sentinel_orbit_file(myfile)
         logging.info("Applying precision orbit information")
-        execute("S1_OPOD_vec {}_001.slc.par {}".format(acqdate,orb))
-        execute("S1_OPOD_vec {}_002.slc.par {}".format(acqdate,orb))
-        execute("S1_OPOD_vec {}_003.slc.par {}".format(acqdate,orb))
-    except:
-        logging.warning("Unable to fetch precision state vectors... continuing")
+        execute("S1_OPOD_vec {}_001.slc.par {}".format(acqdate, orbit_file))
+        execute("S1_OPOD_vec {}_002.slc.par {}".format(acqdate, orbit_file))
+        execute("S1_OPOD_vec {}_003.slc.par {}".format(acqdate, orbit_file))
+    except OrbitDownloadError:
+        logging.warning('Unable to fetch precision state vectors... continuing')
+    except ExecuteError:
+        logging.warning(f'Unable to create *.slc.par files... continuing')
 
     slc = glob.glob("*_00*.slc")
     slc.sort()
@@ -99,14 +105,14 @@ def par_s1_slc_single(myfile, pol=None):
     par.sort()
     top = glob.glob("*_00*.tops_par")
     top.sort()
-    f = open(os.path.join(path,"SLC_TAB"),"w")
+    f = open(os.path.join(path, "SLC_TAB"), "w")
     for i in range(len(slc)):
-        f.write("{} {} {}\n".format(slc[i],par[i],top[i]))
+        f.write("{} {} {}\n".format(slc[i], par[i], top[i]))
     f.close()
 
     #
     # Make a raster version of swath 3
     #
-    width = getParameter("{}_003.slc.par".format(acqdate),"range_samples")
-    execute("rasSLC {}_003.slc {} 1 0 50 10".format(acqdate,width))
+    width = getParameter("{}_003.slc.par".format(acqdate), "range_samples")
+    execute("rasSLC {}_003.slc {} 1 0 50 10".format(acqdate, width))
     os.chdir(wrk)

--- a/hyp3lib/par_s1_slc_single.py
+++ b/hyp3lib/par_s1_slc_single.py
@@ -80,7 +80,7 @@ def par_s1_slc_single(safe_dir, pol='vv', orbit_file=None):
     except OrbitDownloadError:
         logging.warning('Unable to fetch precision state vectors... continuing')
     except ExecuteError:
-        logging.warning(f'Unable to create *.slc.par files... continuing')
+        logging.warning('Unable to create *.slc.par files... continuing')
 
     slc = glob.glob('*_00*.slc')
     slc.sort()

--- a/hyp3lib/par_s1_slc_single.py
+++ b/hyp3lib/par_s1_slc_single.py
@@ -49,18 +49,17 @@ def par_s1_slc_single(safe_dir, pol='vv', orbit_file=None):
     image_type = safe_dir[13:16]
     logging.info(f'Found image type {image_type}')
 
-    folder = safe_dir.replace('.SAFE', '')
     datelong = safe_dir.split('_')[5]
     acquisition_date = (safe_dir.split('_')[5].split('T'))[0]
     path = os.path.join(wrk, acquisition_date)
     if not os.path.exists(path):
         os.mkdir(path)
 
-    logging.info(f'Folder is {folder}')
+    logging.info(f'SAFE directory is {safe_dir}')
     logging.info(f'Long date is {datelong}')
     logging.info(f'Acquisition date is {acquisition_date}')
 
-    os.chdir(f'{folder}.SAFE')
+    os.chdir(safe_dir)
 
     for swath in range(1, 4):
         cmd = make_cmd(swath, acquisition_date, path, pol=pol)

--- a/hyp3lib/par_s1_slc_single.py
+++ b/hyp3lib/par_s1_slc_single.py
@@ -5,7 +5,7 @@ import os
 from hyp3lib import ExecuteError, OrbitDownloadError
 from hyp3lib.execute import execute
 from hyp3lib.getParameter import getParameter
-from hyp3lib.get_orb import download_sentinel_orbit_file
+from hyp3lib.get_orb import downloadSentinelOrbitFile
 
 
 def make_cmd(swath, acquisition_date, out_dir, pol=None):
@@ -72,7 +72,7 @@ def par_s1_slc_single(safe_dir, pol='vv', orbit_file=None):
     try:
         if orbit_file is None:
             logging.info(f'Trying to get orbit file information from file {safe_dir}')
-            orbit_file, _ = download_sentinel_orbit_file(safe_dir)
+            orbit_file, _ = downloadSentinelOrbitFile(safe_dir)
         logging.info('Applying precision orbit information')
         execute(f'S1_OPOD_vec {acquisition_date}_001.slc.par {orbit_file}')
         execute(f'S1_OPOD_vec {acquisition_date}_002.slc.par {orbit_file}')

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
             'pytest',
             'pytest-cov',
             'pytest-console-scripts',
+            'responses',
         ]
     },
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'scipy',
         'six',
         'statsmodels',
+        'urllib3',
     ],
 
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ setup(
         'makeColorPhase.py = hyp3lib.makeColorPhase:main',
         'makeKml.py = hyp3lib.makeKml:main',
         'offset_xml.py = hyp3lib.offset_xml:main',
-        'par_s1_slc_single.py = hyp3lib.par_s1_slc_single:main',
         'ps2dem.py = hyp3lib.ps2dem:main',
         'raster_boundary2shape.py = hyp3lib.raster_boundary2shape:main',
         'rasterMask.py = hyp3lib.rasterMask:main',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,6 @@
-from __future__ import print_function, absolute_import, division, unicode_literals
-
 import os
 import shutil
 import pytest
-
-import requests
-
 
 _HERE = os.path.dirname(__file__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@ import os
 import shutil
 import pytest
 
+import requests
+
+
 _HERE = os.path.dirname(__file__)
 
 

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -133,11 +133,6 @@ def test_offset_xml(script_runner):
     assert ret.success
 
 
-def test_par_s1_slc_single(script_runner):
-    ret = script_runner.run('par_s1_slc_single.py', '-h')
-    assert ret.success
-
-
 def test_ps2dem(script_runner):
     ret = script_runner.run('ps2dem.py', '-h')
     assert ret.success

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,57 @@
+import os
+from datetime import datetime
+
+import pytest
+import requests
+import responses
+
+from hyp3lib import fetch
+
+
+@responses.activate
+def test_download_file(safe_data):
+    with open(os.path.join(safe_data, 'granule_name.txt')) as f:
+        text = f.read()
+
+    responses.add(
+        responses.GET, 'http://hyp3.asf.alaska.edu/foobar.txt', body=text,
+        status=200,
+    )
+
+    download_path = fetch.download_file('http://hyp3.asf.alaska.edu/foobar.txt')
+
+    assert download_path == 'foobar.txt'
+    assert os.path.exists(download_path)
+    with open(download_path) as f:
+        assert f.read() == text
+
+
+@responses.activate
+def test_download_file_in_chunks(safe_data):
+    with open(os.path.join(safe_data, 'granule_name.txt')) as f:
+        text = f.read()
+
+    responses.add(
+        responses.GET, 'http://hyp3.asf.alaska.edu/foobar.txt', body=text,
+        status=200,
+    )
+
+    download_path = fetch.download_file('http://hyp3.asf.alaska.edu/foobar.txt', chunk_size=1)
+
+    assert download_path == 'foobar.txt'
+    assert os.path.exists(download_path)
+    with open(download_path) as f:
+        assert f.read() == text
+
+
+def test_download_file_retries():
+    backoff_factor = 1
+    total_retries = 2
+    expected_time = backoff_factor * (2 ** (total_retries - 1))
+
+    before = datetime.now()
+    with pytest.raises(requests.exceptions.RetryError):
+        _ = fetch.download_file(f'http://httpstat.us/500',
+                                backoff_factor=backoff_factor, retries=total_retries)
+    after = datetime.now()
+    assert (after - before).seconds >= expected_time

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -54,3 +54,8 @@ def test_download_file_retries():
         _ = fetch.download_file('http://httpstat.us/500', backoff_factor=backoff_factor, retries=total_retries)
     after = datetime.now()
     assert (after - before).seconds >= expected_time
+
+
+def test_download_file_none():
+    with pytest.raises(requests.exceptions.InvalidURL):
+        _ = fetch.download_file(url=None)

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -51,7 +51,6 @@ def test_download_file_retries():
 
     before = datetime.now()
     with pytest.raises(requests.exceptions.RetryError):
-        _ = fetch.download_file(f'http://httpstat.us/500',
-                                backoff_factor=backoff_factor, retries=total_retries)
+        _ = fetch.download_file('http://httpstat.us/500', backoff_factor=backoff_factor, retries=total_retries)
     after = datetime.now()
     assert (after - before).seconds >= expected_time

--- a/tests/test_get_orb.py
+++ b/tests/test_get_orb.py
@@ -10,6 +10,7 @@ def test_download_sentinel_orbit_file_esa():
 
     assert provider == 'ESA'
     assert os.path.exists(orbit_file)
+    assert orbit_file == 'S1A_OPER_AUX_POEORB_OPOD_20150711T121908_V20150620T225944_20150622T005944.EOF'
 
 
 def test_download_sentinel_orbit_file_asf():
@@ -17,6 +18,7 @@ def test_download_sentinel_orbit_file_asf():
 
     assert provider == 'ASF'
     assert os.path.exists(orbit_file)
+    assert orbit_file == 'S1A_OPER_AUX_POEORB_OPOD_20150711T121908_V20150620T225944_20150622T005944.EOF'
 
 
 def test_get_orbit_url_esa():

--- a/tests/test_get_orb.py
+++ b/tests/test_get_orb.py
@@ -13,14 +13,6 @@ def test_download_sentinel_orbit_file_esa():
     assert orbit_file == 'S1A_OPER_AUX_POEORB_OPOD_20150711T121908_V20150620T225944_20150622T005944.EOF'
 
 
-def test_download_sentinel_orbit_file_asf():
-    orbit_file, provider = get_orb.downloadSentinelOrbitFile(_GRANULE, providers=('ASF',))
-
-    assert provider == 'ASF'
-    assert os.path.exists(orbit_file)
-    assert orbit_file == 'S1A_OPER_AUX_POEORB_OPOD_20150711T121908_V20150620T225944_20150622T005944.EOF'
-
-
 def test_get_orbit_url_esa():
     orbit_url = get_orb.get_orbit_url(_GRANULE, provider='ESA')
 

--- a/tests/test_get_orb.py
+++ b/tests/test_get_orb.py
@@ -1,0 +1,41 @@
+import os
+
+from hyp3lib import get_orb
+
+_GRANULE = 'S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8'
+
+
+def test_download_sentinel_orbit_file_esa():
+    orbit_file, provider = get_orb.downloadSentinelOrbitFile(_GRANULE, providers=('ESA',))
+
+    assert provider == 'ESA'
+    assert os.path.exists(orbit_file)
+
+
+def test_download_sentinel_orbit_file_asf():
+    orbit_file, provider = get_orb.downloadSentinelOrbitFile(_GRANULE, providers=('ASF',))
+
+    assert provider == 'ASF'
+    assert os.path.exists(orbit_file)
+
+
+def test_get_orbit_url_esa():
+    orbit_url = get_orb.get_orbit_url(_GRANULE, provider='ESA')
+
+    assert 'http://aux.sentinel1.eo.esa.int/POEORB/2015/07/11/' \
+           'S1A_OPER_AUX_POEORB_OPOD_20150711T121908_V20150620T225944_20150622T005944.EOF' \
+           == orbit_url
+
+    orbit_url = get_orb.get_orbit_url(_GRANULE, orbit_type='aux_resorb', provider='ESA')
+
+    assert 'http://aux.sentinel1.eo.esa.int/RESORB/2015/06/21/' \
+           'S1A_OPER_AUX_RESORB_OPOD_20150621T152320_V20150621T111644_20150621T143414.EOF' \
+           == orbit_url
+
+
+def test_get_orbit_url_asf():
+    orbit_url = get_orb.get_orbit_url(_GRANULE, provider='ASF')
+
+    assert 'https://s1qc.asf.alaska.edu/aux_poeorb/' \
+           'S1A_OPER_AUX_POEORB_OPOD_20150711T121908_V20150620T225944_20150622T005944.EOF' \
+           == orbit_url


### PR DESCRIPTION
In order to allow upfront downloading of orbit files, `par_s1_slc_single` and `ingest_S1_granule` accept a new `orbit_file` keyword argument that skips downloading of the orbit files
* Changes to argument names are fine:
  * `ingets_S1_granlue`: https://github.com/search?q=org%3Aasfadmin+org%3AASFHyP3+ingest_S1_granule&type=Code
  * `par_s1_slc_single`: https://github.com/search?q=org%3Aasfadmin+org%3AASFHyP3+par_s1_slc_single&type=Code

This is also a significant refactor of `get_orb` to streamline the fetching routines and simplify the API
* Eliminates:
  * `getPageContentsESA`  b/c functionality has been merged into `get_orbit_url`
  * `getPageContents` (ASF)  b/c functionality has been merged into  `_get_asf_orbit_url`
  * `dateStr2dateTime` because it's entirely unnecessary
  * `findOrbFile` (ASF)  b/c functionality has been merged into  `_get_asf_orbit_url`
  * `getOrbFile` (ASF)  b/c functionality has been merged into  `_get_asf_orbit_url`
  * `getOrbitFileESA` b/c functionality has been merged into  `get_orbit_url`
  * `fetchOrbitFile` uses new `hyp3lib.fetch.download_file` routine
  * `downloadSentinelOrbitFileProvider` b/c functionality has been merged into `download_sentinel_orbit_file`
* Renamed:
  * ~~`downloadSentinelOrbitFile` to `download_sentinel_orbit_file` (API breaking -- may back this off)~~
* Added:
  * `get_orbit_url` will determine the orbit file URL from a provider
  * `_get_asf_orbit_url` private function to query ASF's orbit file list
 
The `get_orb.py` entry point now also allows users to specify a directory they want the orbit file downloaded to

Removes the unused `par_s1_slc_single.py` entrypoint: https://github.com/search?q=org%3Aasfadmin+org%3AASFHyP3+par_s1_slc_single.py&type=Code