### PR TITLE
Orbit and conda env fixes

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -26,11 +26,11 @@ dependencies:
   - requests
   - scipy
   - six
+  - setuptools_scm
   - statsmodels
   - urllib3
   - pip:
     # for packaging and testing
     - s3pypi
-    - setuptools-scm[toml]
     - safety
 

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -20,7 +20,7 @@ dependencies:
   - netCDF4
   - numpy
   - pillow
-  - proj>=2
+  - pyproj>=2
   - pyshp
   - responses
   - requests

--- a/hyp3lib/par_s1_slc_single.py
+++ b/hyp3lib/par_s1_slc_single.py
@@ -73,9 +73,9 @@ def par_s1_slc_single(safe_dir, pol='vv', orbit_file=None):
             logging.info(f'Trying to get orbit file information from file {safe_dir}')
             orbit_file, _ = downloadSentinelOrbitFile(safe_dir)
         logging.info('Applying precision orbit information')
-        execute(f'S1_OPOD_vec {acquisition_date}_001.slc.par {orbit_file}')
-        execute(f'S1_OPOD_vec {acquisition_date}_002.slc.par {orbit_file}')
-        execute(f'S1_OPOD_vec {acquisition_date}_003.slc.par {orbit_file}')
+        execute(f'S1_OPOD_vec {acquisition_date}_001.slc.par {orbit_file}', uselogging=True)
+        execute(f'S1_OPOD_vec {acquisition_date}_002.slc.par {orbit_file}', uselogging=True)
+        execute(f'S1_OPOD_vec {acquisition_date}_003.slc.par {orbit_file}', uselogging=True)
     except OrbitDownloadError:
         logging.warning('Unable to fetch precision state vectors... continuing')
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'Topic :: Software Development :: Libraries',
         ],
 
-    # python_requires='~=3.6',
+    python_requires='~=3.6',
 
     install_requires=[
         'boto3',


### PR DESCRIPTION
* Use logging for both GRDs and SLCs when calling `S1_OPOD_vec`
* fix constraint of `pyproj` in conda env (pyproj requires `proj >6=.3`)
* restricts python to `>=3.6` is `setup.py` (we use f-strings, so that's the minimum version)