### PR TITLE
Remove exact duplicate raster_metadata

### DIFF
--- a/hyp3lib/raster_boundary2shape.py
+++ b/hyp3lib/raster_boundary2shape.py
@@ -3,73 +3,10 @@
 import argparse
 import os
 
-from osgeo import ogr
 from scipy import ndimage
 
-from hyp3lib.asf_geometry import raster_meta, geotiff2boundary_mask, data_geometry2shape
-
-
-# from hyp3lib.asf_time_series import raster_metadata
-def raster_metadata(input):
-
-  # Set up shapefile attributes
-  fields = []
-  field = {}
-  values = []
-  field['name'] = 'granule'
-  field['type'] = ogr.OFTString
-  field['width'] = 254
-  fields.append(field)
-  field = {}
-  field['name'] = 'epsg'
-  field['type'] = ogr.OFTInteger
-  fields.append(field)
-  field = {}
-  field['name'] = 'originX'
-  field['type'] = ogr.OFTReal
-  fields.append(field)
-  field = {}
-  field['name'] = 'originY'
-  field['type'] = ogr.OFTReal
-  fields.append(field)
-  field = {}
-  field['name'] = 'pixSize'
-  field['type'] = ogr.OFTReal
-  fields.append(field)
-  field = {}
-  field['name'] = 'cols'
-  field['type'] = ogr.OFTInteger
-  fields.append(field)
-  field = {}
-  field['name'] = 'rows'
-  field['type'] = ogr.OFTInteger
-  fields.append(field)
-  field = {}
-  field['name'] = 'pixel'
-  field['type'] = ogr.OFTString
-  field['width'] = 8
-  fields.append(field)
-
-  # Extract other raster image metadata
-  (outSpatialRef, outGt, outShape, outPixel) = raster_meta(input)
-  if outSpatialRef.GetAttrValue('AUTHORITY', 0) == 'EPSG':
-    epsg = int(outSpatialRef.GetAttrValue('AUTHORITY', 1))
-
-  # Add granule name and geometry
-  base = os.path.basename(input)
-  granule = os.path.splitext(base)[0]
-  value = {}
-  value['granule'] = granule
-  value['epsg'] = epsg
-  value['originX'] = outGt[0]
-  value['originY'] = outGt[3]
-  value['pixSize'] = outGt[1]
-  value['cols'] = outShape[1]
-  value['rows'] = outShape[0]
-  value['pixel'] = outPixel
-  values.append(value)
-
-  return (fields, values, outSpatialRef)
+from hyp3lib.asf_geometry import geotiff2boundary_mask, data_geometry2shape
+from hyp3lib.asf_time_series import raster_metadata
 
 
 def raster_boundary2shape(inFile, threshold, outShapeFile, use_closing=True, fill_holes = False,


### PR DESCRIPTION
`hyp3lib.raster_boundary2shape.raster_metadata` was an exact duplicate of `hyp3lib.asf_time_series.rater_metadata` and has been removed (as well as no longer used imports)