### PR TITLE
Don't duplicate conda channels

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -32,7 +32,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: hyp3-lib
           environment-file: conda-env.yml
-          channels: conda-forge, nodefaults
 
       - name: Pytest in conda environment
         shell: bash -l {0}
@@ -155,7 +154,6 @@ jobs:
           python-version: 3.7
           activate-environment: hyp3-lib
           environment-file: conda-env.yml
-          channels: conda-forge, nodefaults
 
       - name: Pip install ${{ needs.package.outputs.SDIST_VERSION }}
         shell: bash -l {0}


### PR DESCRIPTION
Eliminates warning in Github Actions workflow