### PR TITLE
Refactor get_dem and getDemFor

### DIFF
--- a/hyp3lib/getDemFor.py
+++ b/hyp3lib/getDemFor.py
@@ -1,37 +1,40 @@
 """Get a DEM file for a given sentinel1 SAFE file"""
 
-from __future__ import print_function, absolute_import, division, unicode_literals
+import argparse
+import logging
+import os
+import shutil
+
+from osgeo import gdal
 
 from hyp3lib import get_dem
-import os
-import argparse
-from hyp3lib.getSubSwath import get_bounding_box_file
 from hyp3lib.execute import execute
-from osgeo import gdal
-import shutil
-import logging
+from hyp3lib.getSubSwath import get_bounding_box_file
 from hyp3lib.saa_func_lib import get_utm_proj
 
 
-def getDemFile(infile,outfile,opentopoFlag=None,utmFlag=True,post=None,demName=None):
-    lat_max,lat_min,lon_max,lon_min = get_bounding_box_file(infile)
-    if opentopoFlag:
-        cmd = "wget -O%s \"http://opentopo.sdsc.edu/otr/getdem?demtype=SRTMGL1&west=%s&south=%s&east=%s&north=%s&outputFormat=GTiff\"" % (outfile,lon_min,lat_min,lon_max,lat_max)
-        execute(cmd)
-        if utmFlag:
-            proj = get_utm_proj(lon_min,lon_max,lat_min,lat_max)
-            tmpdem = "tmpdem_getDemFile_utm.tif"
-            gdal.Warp("%s" %tmpdem,"%s" % outfile,dstSRS=proj,resampleAlg="cubic")
-            shutil.move(tmpdem,"%s" % outfile)
+def get_dem_file(infile, outfile: str, use_opentopo=False, in_utm=True, post=None, dem_name=None):
+    lat_max, lat_min, lon_max, lon_min = get_bounding_box_file(infile)
+    if use_opentopo:
+        demtype = None
+        url = f'http://opentopo.sdsc.edu/otr/getdem' \
+              f'?demtype=SRTMGL1&west={lon_min}&south={lat_min}&east={lon_max}&north={lat_max}&outputFormat=GTiff'
+        execute(f'wget -O {outfile} "{url}"')
+
+        if in_utm:
+            proj = get_utm_proj(lon_min, lon_max, lat_min, lat_max)
+            tmpdem = 'tmpdem_getDemFile_utm.tif'
+            gdal.Warp(tmpdem, outfile, dstSRS=proj, resampleAlg='cubic')
+            shutil.move(tmpdem, outfile)
     else:
-        if utmFlag:
-            demtype = get_dem.get_dem(lon_min,lat_min,lon_max,lat_max,outfile,post=post,demName=demName)
+        if in_utm:
+            demtype = get_dem.get_dem(lon_min, lat_min, lon_max, lat_max, outfile, post=post, dem_name=dem_name)
             if not os.path.isfile(outfile):
-                logging.error("Unable to find output file {}".format(outfile))
+                logging.error(f'Unable to find output file {outfile}')
         else:
-            demtype = get_dem.get_ll_dem(lon_min,lat_min,lon_max,lat_max,outfile,post=post,demName=demName)
-            
-    return(outfile,demtype)
+            demtype = get_dem.get_ll_dem(lon_min, lat_min, lon_max, lat_max, outfile, post=post, dem_name=dem_name)
+
+    return outfile, demtype
 
 
 def main():
@@ -41,24 +44,24 @@ def main():
         prog=os.path.basename(__file__),
         description=__doc__,
     )
-    parser.add_argument("SAFEfile",help="S1 SAFE file")
-    parser.add_argument("outfile",help="Name of output geotiff DEM file")
-    parser.add_argument("-o","--opentopo",action="store_true",help="Use opentopo instead of get_dem")
-    parser.add_argument("-l","--latlon",action="store_false",
-        help="Create DEM in lat,lon space - dangerous option for polar imagery")
-    parser.add_argument("-d","--dem",help="Only use the specified DEM type")
-    parser.add_argument("-p","--post",help="Posting for creating DEM",type=float)
+    parser.add_argument("SAFEfile", help="S1 SAFE file")
+    parser.add_argument("outfile", help="Name of output geotiff DEM file")
+    parser.add_argument("-o", "--opentopo", action="store_true", help="Use opentopo instead of get_dem")
+    parser.add_argument("-l", "--latlon", action="store_false",
+                        help="Create DEM in lat,lon space - dangerous option for polar imagery")
+    parser.add_argument("-d", "--dem", help="Only use the specified DEM type")
+    parser.add_argument("-p", "--post", help="Posting for creating DEM", type=float)
     args = parser.parse_args()
 
-    logFile = "getDemFor_{}.log".format(os.getpid())
-    logging.basicConfig(filename=logFile,format='%(asctime)s - %(levelname)s - %(message)s',
-                        datefmt='%m/%d/%Y %I:%M:%S %p',level=logging.DEBUG)
+    log_file = f'getDemFor_{os.getpid()}.log'
+    logging.basicConfig(filename=log_file, format='%(asctime)s - %(levelname)s - %(message)s',
+                        datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.DEBUG)
     logging.getLogger().addHandler(logging.StreamHandler())
-    logging.info("Starting run")
+    logging.info('Starting run')
 
-    outfile,demtype = getDemFile(args.SAFEfile,args.outfile,opentopoFlag=args.opentopo,
-                                 utmFlag=args.latlon,post=args.post,demName=args.dem)
-    logging.info("Wrote DEM file %s" % outfile)
+    outfile, demtype = get_dem_file(args.SAFEfile, args.outfile, use_opentopo=args.opentopo,
+                                    in_utm=args.latlon, post=args.post, dem_name=args.dem)
+    logging.info(f'Wrote DEM file {outfile}')
 
 
 if __name__ == '__main__':

--- a/hyp3lib/getDemFor.py
+++ b/hyp3lib/getDemFor.py
@@ -7,7 +7,7 @@ import shutil
 
 from osgeo import gdal
 
-from hyp3lib import get_dem
+from hyp3lib.get_dem import get_dem
 from hyp3lib.execute import execute
 from hyp3lib.getSubSwath import get_bounding_box_file
 from hyp3lib.saa_func_lib import get_utm_proj
@@ -15,6 +15,7 @@ from hyp3lib.saa_func_lib import get_utm_proj
 
 def get_dem_file(infile, outfile: str, use_opentopo=False, in_utm=True, post=None, dem_name=None):
     lat_max, lat_min, lon_max, lon_min = get_bounding_box_file(infile)
+
     if use_opentopo:
         demtype = None
         url = f'http://opentopo.sdsc.edu/otr/getdem' \
@@ -27,12 +28,12 @@ def get_dem_file(infile, outfile: str, use_opentopo=False, in_utm=True, post=Non
             gdal.Warp(tmpdem, outfile, dstSRS=proj, resampleAlg='cubic')
             shutil.move(tmpdem, outfile)
     else:
-        if in_utm:
-            demtype = get_dem.get_dem(lon_min, lat_min, lon_max, lat_max, outfile, post=post, dem_name=dem_name)
-            if not os.path.isfile(outfile):
-                logging.error(f'Unable to find output file {outfile}')
-        else:
-            demtype = get_dem.get_ll_dem(lon_min, lat_min, lon_max, lat_max, outfile, post=post, dem_name=dem_name)
+        dem_type = 'utm' if in_utm else 'latlon'
+        demtype = get_dem(
+            lon_min, lat_min, lon_max, lat_max, outfile, post=post, dem_name=dem_name, dem_type=dem_type
+        )
+        if not os.path.isfile(outfile):
+            logging.error(f'Unable to find output file {outfile}')
 
     return outfile, demtype
 

--- a/hyp3lib/getDemFor.py
+++ b/hyp3lib/getDemFor.py
@@ -13,7 +13,7 @@ from hyp3lib.getSubSwath import get_bounding_box_file
 from hyp3lib.saa_func_lib import get_utm_proj
 
 
-def get_dem_file(infile, outfile: str, use_opentopo=False, in_utm=True, post=None, dem_name=None):
+def getDemFile(infile, outfile: str, use_opentopo=False, in_utm=True, post=None, dem_name=None):
     lat_max, lat_min, lon_max, lon_min = get_bounding_box_file(infile)
 
     if use_opentopo:
@@ -60,8 +60,8 @@ def main():
     logging.getLogger().addHandler(logging.StreamHandler())
     logging.info('Starting run')
 
-    outfile, demtype = get_dem_file(args.SAFEfile, args.outfile, use_opentopo=args.opentopo,
-                                    in_utm=args.latlon, post=args.post, dem_name=args.dem)
+    outfile, demtype = getDemFile(args.SAFEfile, args.outfile, use_opentopo=args.opentopo,
+                                  in_utm=args.latlon, post=args.post, dem_name=args.dem)
     logging.info(f'Wrote DEM file {outfile}')
 
 

--- a/hyp3lib/get_dem.py
+++ b/hyp3lib/get_dem.py
@@ -168,7 +168,7 @@ def get_corner_coordinates_from_gdal_info(info):
 
 def get_cc(tmpproj, post):
     shift = 0
-    info = subprocess.check_output('gdalinfo %s' % tmpproj, shell=True, universal_newlines=True)
+    info = subprocess.check_output(f'gdalinfo {tmpproj}', shell=True, universal_newlines=True)
     coords = get_corner_coordinates_from_gdal_info(info)
 
     easts = [c[0] for c in coords.values()]
@@ -291,7 +291,7 @@ def get_ll_dem(west, south, east, north, out_dem, post=None, processes=1, dem_na
 
 def get_dem(x_min, y_min, x_max, y_max, outfile, post=None, processes=1, dem_name=None, leave=False):
     if post is not None:
-        logging.info("Snapping to grid at posting of %s meters" % post)
+        logging.info(f"Snapping to grid at posting of {post} meters")
 
     if y_min < -90 or y_max > 90:
         raise ValueError(f"Please use latitude in range (-90, 90) ({y_min}, {y_max})")
@@ -488,7 +488,7 @@ def clean_dem(in_dem, out_dem):
 
 def snap_to_grid(post, pixsize, infile, outfile):
     if post:
-        logging.info("Snapping file to grid at %s meters" % post)
+        logging.info(f"Snapping file to grid at {post} meters")
         (e_min, e_max, n_min, n_max) = get_cc(infile, post)
         bounds = [e_min, n_min, e_max, n_max]
         gdal.Warp(outfile, infile, xRes=pixsize, yRes=pixsize, outputBounds=bounds, resampleAlg="cubic",

--- a/hyp3lib/get_dem.py
+++ b/hyp3lib/get_dem.py
@@ -531,8 +531,10 @@ def main():
     else:
         dem_type = 'utm'
 
-    get_dem(args.x_min, args.y_min, args.x_max, args.y_max, args.outfile, post=args.posting,
-                   leave=args.keep, processes=args.threads, dem_name=args.dem, dem_type=dem_type)
+    get_dem(
+        args.x_min, args.y_min, args.x_max, args.y_max, args.outfile,
+        post=args.posting, leave=args.keep, processes=args.threads, dem_name=args.dem, dem_type=dem_type
+    )
 
 
 if __name__ == "__main__":

--- a/hyp3lib/get_dem.py
+++ b/hyp3lib/get_dem.py
@@ -7,6 +7,7 @@ import multiprocessing as mp
 import os
 import shutil
 import subprocess
+import sys
 
 import boto3
 import lxml.etree as et
@@ -24,15 +25,7 @@ from hyp3lib import saa_func_lib as saa
 from hyp3lib.asf_geometry import raster_meta
 
 
-def positive_int(value):
-    ivalue = int(value)
-    if ivalue <= 0:
-        raise argparse.ArgumentTypeError(f"{value} is an invalid positive int value")
-    return ivalue
-
-
 def reproject_wkt(wkt, in_epsg, out_epsg):
-
     source = osr.SpatialReference()
     source.ImportFromEPSG(in_epsg)
 
@@ -44,32 +37,31 @@ def reproject_wkt(wkt, in_epsg, out_epsg):
     geom = ogr.CreateGeometryFromWkt(wkt)
     geom.Transform(transform)
 
-    return(geom.ExportToWkt())
+    return geom.ExportToWkt()
 
 
-def get_best_dem(y_min,y_max,x_min,x_max,demName=None):
-
+def get_best_dem(y_min, y_max, x_min, x_max, dem_name=None):
     driver = ogr.GetDriverByName('ESRI Shapefile')
     shpdir = os.path.abspath(os.path.join(os.path.dirname(hyp3lib.etc.__file__), "config"))
 
     # Read in the DEM list
     dem_list = []
-    myfile = os.path.join(shpdir,"get_dem.py.cfg")
+    myfile = os.path.join(shpdir, "get_dem.py.cfg")
     with open(myfile) as f:
         content = f.readlines()
         for item in content:
-            dem_list.append([item.split()[0],item.split()[2]]) 
-    logging.info("dem_list {}".format(dem_list))
+            dem_list.append([item.split()[0], item.split()[2]])
+    logging.info(f"dem_list {dem_list}")
 
     # If a dem is specified, use it instead of the list
-    if demName:
+    if dem_name:
         new_dem_list = []
         for item in dem_list:
-            if demName in item[0] and len(demName)==len(item[0]):
-                new_dem_list.append([demName,item[1]])
+            if dem_name in item[0] and len(dem_name) == len(item[0]):
+                new_dem_list.append([dem_name, item[1]])
         dem_list = new_dem_list
 
-    scene_wkt = "POLYGON ((%s %s, %s %s, %s %s, %s %s, %s %s))" % (x_min,y_min,x_max,y_min,x_max,y_max,x_min,y_max,x_min,y_min)
+    scene_wkt = f"POLYGON (({x_min} {y_min}, {x_max} {y_min}, {x_max} {y_max}, {x_min} {y_max}, {x_min} {y_min}))"
 
     best_pct = 0
     best_name = ""
@@ -78,15 +70,15 @@ def get_best_dem(y_min,y_max,x_min,x_max,demName=None):
     best_poly_list = []
 
     for item in dem_list:
-        DEM = item[0].lower()
-        demEPSG = int(item[1])
-        if demEPSG != 4326:
-            logging.info("Reprojecting corners into projection {}".format(demEPSG))
-            proj_wkt = reproject_wkt(scene_wkt,4326,int(demEPSG))
+        dem = item[0].lower()
+        dem_epsg = int(item[1])
+        if dem_epsg != 4326:
+            logging.info(f"Reprojecting corners into projection {dem_epsg}")
+            proj_wkt = reproject_wkt(scene_wkt, 4326, int(dem_epsg))
         else:
-            proj_wkt = scene_wkt 
+            proj_wkt = scene_wkt
 
-        dataset = driver.Open(os.path.join(shpdir,DEM+'_coverage.shp'), 0)
+        dataset = driver.Open(os.path.join(shpdir, dem + '_coverage.shp'), 0)
         poly = ogr.CreateGeometryFromWkt(proj_wkt)
         total_area = poly.GetArea()
         coverage = 0
@@ -104,146 +96,146 @@ def get_best_dem(y_min,y_max,x_min,x_max,demName=None):
             if a > 0:
                 poly_list.append(wkt)
                 tile = str(feature.GetFieldAsString(feature.GetFieldIndex("tile")))
-                # logging.info("Working on tile {}".format(tile))
+                # logging.info(f"Working on tile {tile}")
                 coverage += a
                 tiles += "," + tile
                 tile_list.append(tile)
 
-        logging.info("Totals: {} {} {} {}".format(DEM, coverage, total_area,
-          coverage/total_area))
-        pct = coverage/total_area
+        logging.info(f"Totals: {dem} {coverage} {total_area} {coverage / total_area}")
+        pct = coverage / total_area
         if pct >= .99:
             best_pct = pct
-            best_name = DEM.upper()
+            best_name = dem.upper()
             best_tile_list = tile_list
-            best_epsg = demEPSG
+            best_epsg = dem_epsg
             best_poly_list = poly_list
             break
-        if best_pct == 0 or pct > best_pct+0.05:
+        if best_pct == 0 or pct > best_pct + 0.05:
             best_pct = pct
-            best_name = DEM.upper()
+            best_name = dem.upper()
             best_tile_list = tile_list
-            best_epsg = demEPSG
+            best_epsg = dem_epsg
             best_poly_list = poly_list
 
     if best_pct < .20:
         raise DemError("Unable to find a DEM file for that area")
 
-    logging.info("Best DEM: {}".format(best_name))
-    logging.info("Tile List: {}".format(best_tile_list))
-    return(best_name, best_epsg, best_tile_list, best_poly_list)
+    logging.info(f"Best DEM: {best_name}")
+    logging.info(f"Tile List: {best_tile_list}")
+    return best_name, best_epsg, best_tile_list, best_poly_list
 
 
 def get_tile_for(args):
     demname, fi = args
     cfgdir = os.path.abspath(os.path.join(os.path.dirname(hyp3lib.etc.__file__), "config"))
-    myfile = os.path.join(cfgdir,"get_dem.py.cfg")
+    myfile = os.path.join(cfgdir, "get_dem.py.cfg")
 
     with open(myfile) as f:
         content = f.readlines()
         for item in content:
             if demname in item.split()[0] and len(demname) == len(item.split()[0]):
-                (mydir,myfile) = os.path.split(item)
+                (mydir, myfile) = os.path.split(item)
                 mydir = mydir.split()[1]
                 if "s3" in mydir:
-                    myfile = os.path.join(demname,fi)+".tif"
+                    myfile = os.path.join(demname, fi) + ".tif"
                     s3 = boto3.resource('s3')
                     s3.meta.client.meta.events.register('choose-signer.s3.*', disable_signing)
                     mybucket = mydir.split("/")[-1]
-                    s3.Bucket(mybucket).download_file(myfile,"DEM/{}.tif".format(fi))
+                    s3.Bucket(mybucket).download_file(myfile, f"DEM/{fi}.tif")
                 else:
-                    myfile = os.path.join(mydir,demname,"geotiff",fi) + ".tif"
-                    output = "DEM/%s" % fi + ".tif"
+                    myfile = os.path.join(mydir, demname, "geotiff", fi) + ".tif"
+                    output = f"DEM/{fi}].tif"
                     shutil.copy(myfile, output)
 
 
-def parseString(string):
-    l = string.split("(")
-    m = l[1].split(",")
-    n = m[0]
-    o = m[1].split(")")[0]
-    return(float(n),float(o))
+def _parse_gdal_coordinate_line(line):
+    """returns (394560.0, 5922090.0) from a line like:
+        Upper Left  (  394560.000, 5922090.000) (  1d24'45.77"E, 53d26'14.23"N)
+    """
+    east, north = line.split('(')[1].strip().rstrip(')').split(',')
+    return float(east), float(north)
 
 
-def get_cc(tmpproj,post,pixsize):
+def get_corner_coordinates_from_gdal_info(info):
+    coords = {}
+    keys = ['Upper Left', 'Lower Left', 'Upper Right', 'Lower Right']
+    for line in info.split('\n'):
+        for key in keys:
+            if key in line:
+                coords[key] = _parse_gdal_coordinate_line(line)
+    return coords
 
+
+def get_cc(tmpproj, post):
     shift = 0
-    string = subprocess.check_output('gdalinfo %s' % tmpproj, shell=True, universal_newlines=True)
-    lst = string.split("\n")
-    for item in lst:
-        if "Upper Left" in item:
-            (east1,north1) = parseString(item)
-        if "Lower Left" in item:
-            (east2,north2) = parseString(item)
-        if "Upper Right" in item:
-            (east3,north3) = parseString(item)
-        if "Lower Right" in item:
-            (east4,north4) = parseString(item)
+    info = subprocess.check_output('gdalinfo %s' % tmpproj, shell=True, universal_newlines=True)
+    coords = get_corner_coordinates_from_gdal_info(info)
 
-    e_min = min(east1,east2,east3,east4)
-    e_max = max(east1,east2,east3,east4)
-    n_min = min(north1,north2,north3,north4)
-    n_max = max(north1,north2,north3,north4)
+    easts = [c[0] for c in coords.values()]
+    norths = [c[1] for c in coords.values()]
 
-    e_max = math.ceil(e_max/post)*post+shift
-    e_min = math.floor(e_min/post)*post-shift
-    n_max = math.ceil(n_max/post)*post+shift
-    n_min = math.floor(n_min/post)*post-shift
+    e_max = math.ceil(max(easts) / post) * post + shift
+    e_min = math.floor(min(easts) / post) * post - shift
+    n_max = math.ceil(max(norths) / post) * post + shift
+    n_min = math.floor(min(norths) / post) * post - shift
 
-    logging.info("New coordinates: %f %f %f %f" % (e_max,e_min,n_max,n_min))
-    return(e_min,e_max,n_min,n_max)
+    logging.info("New coordinates: %f %f %f %f" % (e_max, e_min, n_max, n_min))
+    return e_min, e_max, n_min, n_max
 
 
-def writeVRT(dem_proj, nodata, tile_list, poly_list, outFile):
-
+def write_vrt(dem_proj, nodata, tile_list, poly_list, out_file):
     # Get dimensions and pixel size from first DEM in tile ListCommand
-    demFile = os.path.join('DEM', '{0}.tif'.format(tile_list[0]))
-    (spatialRef, gt, shape, pixel) = raster_meta(demFile)
-    (rows, cols) = shape
-    pixSize = gt[1]
+    dem_file = os.path.join('DEM', f'{tile_list[0]}.tif')
+    spatial_ref, gt, shape, pixel = raster_meta(dem_file)
+    rows, cols = shape
+    pix_size = gt[1]
 
     # Determine coverage
-    minLon = 360
-    maxLon = -180
-    minLat = 90
-    maxLat = -90
+    min_lon = 360
+    max_lon = -180
+    min_lat = 90
+    max_lat = -90
     for poly in poly_list:
         polygon = ogr.CreateGeometryFromWkt(poly)
         envelope = polygon.GetEnvelope()
-        if envelope[0] < minLon: minLon = envelope[0]
-        if envelope[1] > maxLon: maxLon = envelope[1]
-        if envelope[2] < minLat: minLat = envelope[2]
-        if envelope[3] > maxLat: maxLat = envelope[3]
-    rasterXSize = np.int(np.rint((maxLon-minLon)/pixSize)) + 1
-    rasterYSize = np.int(np.rint((maxLat-minLat)/pixSize)) + 1
+        if envelope[0] < min_lon:
+            min_lon = envelope[0]
+        if envelope[1] > max_lon:
+            max_lon = envelope[1]
+        if envelope[2] < min_lat:
+            min_lat = envelope[2]
+        if envelope[3] > max_lat:
+            max_lat = envelope[3]
+
+    raster_x_size = np.int(np.rint((max_lon - min_lon) / pix_size)) + 1
+    raster_y_size = np.int(np.rint((max_lat - min_lat) / pix_size)) + 1
 
     # Determine offsets
-    offsetX = []
-    offsetY = []
+    offset_x = []
+    offset_y = []
     for poly in poly_list:
         polygon = ogr.CreateGeometryFromWkt(poly)
         envelope = polygon.GetEnvelope()
-        offsetX.append(np.int(np.rint((envelope[0] - minLon)/pixSize)))
-        offsetY.append(np.int(np.rint((maxLat - envelope[3])/pixSize)))
+        offset_x.append(np.int(np.rint((envelope[0] - min_lon) / pix_size)))
+        offset_y.append(np.int(np.rint((max_lat - envelope[3]) / pix_size)))
 
     # Generate XML structure
-    vrt = et.Element('VRTDataset', rasterXSize=str(rasterXSize),
-        rasterYSize=str(rasterYSize))
+    vrt = et.Element('VRTDataset', rasterXSize=str(raster_x_size),
+                     rasterYSize=str(raster_y_size))
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(dem_proj)
     et.SubElement(vrt, 'SRS').text = srs.ExportToWkt()
-    geoTrans = ('%.16f, %.16f, 0.0, %.16f, 0.0, %.16f' % (minLon, pixSize, maxLat,
-        -pixSize))
-    et.SubElement(vrt, 'GeoTransform').text = geoTrans
+    geo_trans = f'{min_lon:.16f}, {pix_size:.16f}, 0.0, {max_lat:.16f}, 0.0, {-pix_size:.16f}'
+    et.SubElement(vrt, 'GeoTransform').text = geo_trans
     bands = et.SubElement(vrt, 'VRTRasterBand', dataType='Float32', band='1')
     et.SubElement(bands, 'NoDataValue').text = '-32768'
     et.SubElement(bands, 'ColorInterp').text = 'Gray'
-    tileCount = len(tile_list)
-    for ii in range(tileCount):
+    tile_count = len(tile_list)
+    for ii in range(tile_count):
         source = et.SubElement(bands, 'ComplexSource')
-        demFile = os.path.join('DEM', '{0}.tif'.format(tile_list[ii]))
+        dem_file = os.path.join('DEM', f'{tile_list[ii]}.tif')
         et.SubElement(source, 'SourceFilename', relativeToVRT='1').text = \
-            demFile
+            dem_file
         et.SubElement(source, 'SourceBand').text = '1'
         properties = et.SubElement(source, 'SourceProperties')
         properties.set('RasterXSize', str(cols))
@@ -257,43 +249,47 @@ def writeVRT(dem_proj, nodata, tile_list, poly_list, outFile):
         src.set('xSize', str(cols))
         src.set('ySize', str(rows))
         dst = et.SubElement(source, 'DstRect')
-        dst.set('xOff', str(offsetX[ii]))
-        dst.set('yOff', str(offsetY[ii]))
+        dst.set('xOff', str(offset_x[ii]))
+        dst.set('yOff', str(offset_y[ii]))
         dst.set('xSize', str(cols))
         dst.set('ySize', str(rows))
-        et.SubElement(source, 'NODATA').text = "{}".format(nodata)
+        et.SubElement(source, 'NODATA').text = f"{nodata}"
 
     # Write VRT file
-    with open(outFile, 'wb') as outF:
+    with open(out_file, 'wb') as outF:
         outF.write(et.tostring(vrt, xml_declaration=False, encoding='utf-8',
-            pretty_print=True))
+                               pretty_print=True))
 
 
-def get_ISCE_dem(west,south,east,north,demName,demXMLName):
+def get_ISCE_dem(west, south, east, north, dem_name, dem_xml_name):
     """GET DEM file and convert into ISCE format"""
     # Get the DEM file
-    chosen_dem = get_dem(west,south,east,north,"temp_dem.tif")
+    chosen_dem = get_dem(west, south, east, north, "temp_dem.tif")
 
     # Reproject DEM into Lat, Lon space
     pixsize = 0.000277777777778
-    gdal.Warp(demName,"temp_dem.tif",format="ENVI",dstSRS="EPSG:4326",xRes=pixsize,yRes=pixsize,resampleAlg="cubic",dstNodata=-32767)
-    ext = os.path.splitext(demName)[1]
-    hdrName = demName.replace(ext,".hdr")
-    dem2isce.dem2isce(demName,hdrName,demXMLName)
+    gdal.Warp(dem_name, "temp_dem.tif", format="ENVI", dstSRS="EPSG:4326", xRes=pixsize, yRes=pixsize,
+              resampleAlg="cubic", dstNodata=-32767)
+    ext = os.path.splitext(dem_name)[1]
+    hdr_name = dem_name.replace(ext, ".hdr")
+    dem2isce.dem2isce(dem_name, hdr_name, dem_xml_name)
     return chosen_dem
 
 
-def get_ll_dem(west,south,east,north,outDem,post=None,processes=1,demName=None,leave=False):
+def get_ll_dem(west, south, east, north, out_dem, post=None, processes=1, dem_name=None, leave=False):
     """GET DEM file and convert into lat,lon format"""
-    demType = get_dem(west,south,east,north,"temp_dem.tif",post=post,processes=processes,demName=demName,leave=leave)
+    dem_type = get_dem(
+        west, south, east, north, "temp_dem.tif", post=post, processes=processes, dem_name=dem_name, leave=leave
+    )
     pixsize = 0.000277777777778
-    gdal.Warp(outDem,"temp_dem.tif",dstSRS="EPSG:4326",xRes=pixsize,yRes=pixsize,resampleAlg="cubic",dstNodata=-32767)
+    gdal.Warp(
+        out_dem, "temp_dem.tif", dstSRS="EPSG:4326", xRes=pixsize, yRes=pixsize, resampleAlg="cubic", dstNodata=-32767
+    )
     os.remove("temp_dem.tif")
-    return(demType)
+    return dem_type
 
 
-def get_dem(x_min,y_min,x_max,y_max,outfile,post=None,processes=1,demName=None,leave=False):
-
+def get_dem(x_min, y_min, x_max, y_max, outfile, post=None, processes=1, dem_name=None, leave=False):
     if post is not None:
         logging.info("Snapping to grid at posting of %s meters" % post)
 
@@ -309,9 +305,9 @@ def get_dem(x_min,y_min,x_max,y_max,outfile,post=None,processes=1,demName=None,l
         (y_min, y_max) = (y_max, y_min)
 
     # Figure out which DEM and get the tile list
-    (demname, demproj, tile_list, poly_list) = get_best_dem(y_min,y_max,x_min,x_max,demName=demName)
+    (demname, demproj, tile_list, poly_list) = get_best_dem(y_min, y_max, x_min, x_max, dem_name=dem_name)
     demproj = int(demproj)
-    logging.info("demproj is {}".format(demproj))
+    logging.info(f"demproj is {demproj}")
 
     # Add buffer for REMA
     if 'REMA' in demname or 'GIMP' in demname:
@@ -335,7 +331,7 @@ def get_dem(x_min,y_min,x_max,y_max,outfile,post=None,processes=1,demName=None,l
     p.close()
     p.join()
 
-    #os.system("gdalbuildvrt temp.vrt DEM/*.tif")
+    # os.system("gdalbuildvrt temp.vrt DEM/*.tif")
     if "SRTMGL" in demname:
         nodata = -32768
     elif "GIMP" in demname:
@@ -347,34 +343,34 @@ def get_dem(x_min,y_min,x_max,y_max,outfile,post=None,processes=1,demName=None,l
     else:
         raise DemError(f'Unable to determine NoData value for DEM {demname}')
 
-    writeVRT(demproj, nodata, tile_list, poly_list, 'temp.vrt')
- 
+    write_vrt(demproj, nodata, tile_list, poly_list, 'temp.vrt')
+
     #
     # Set the output projection to either NPS, SPS, or UTM
     #
-    if demproj == 3413: 	# North Polar Stereo
-        outproj = ('EPSG:3413')
+    if demproj == 3413:  # North Polar Stereo
+        outproj = 'EPSG:3413'
         outproj_num = 3413
-    elif demproj == 3031:        # South Polar Stereo
-        outproj = ('EPSG:3031')
+    elif demproj == 3031:  # South Polar Stereo
+        outproj = 'EPSG:3031'
         outproj_num = 3031
     else:
-        lon = (x_max+x_min)/2
-        zone = math.floor((lon+180)/6+1)
+        lon = (x_max + x_min) / 2
+        zone = math.floor((lon + 180) / 6 + 1)
         if zone > 60:
             zone -= 60
-        if (y_min+y_max)/2 > 0:
+        if (y_min + y_max) / 2 > 0:
             outproj = ('EPSG:326%02d' % int(zone))
-            outproj_num = int("326%02d"%int(zone))
+            outproj_num = int("326%02d" % int(zone))
         else:
             outproj = ('EPSG:327%02d' % int(zone))
-            outproj_num = int("327%02d"%int(zone))
-     
+            outproj_num = int("327%02d" % int(zone))
+
     tmpdem = "xxyyzz_img.tif"
     tmpdem2 = "aabbcc_img.tif"
     tmpproj = "lmnopqr_img.tif"
     if os.path.isfile(tmpdem):
-        logging.info("Removing old file {}".format(tmpdem))
+        logging.info(f"Removing old file {tmpdem}")
         os.remove(tmpdem)
     if os.path.isfile(tmpproj):
         logging.info("Removing old file projected dem file")
@@ -385,15 +381,14 @@ def get_dem(x_min,y_min,x_max,y_max,outfile,post=None,processes=1,demName=None,l
 
     if demname == "SRTMGL3":
         pixsize = 90.
-        gcssize = gcssize * 3
+        gcssize *= 3
     if demname == "NED2":
         pixsize = 60.
-        gcssize = gcssize * 2
-
+        gcssize *= 2
 
     logging.info("Creating initial raster file")
-    logging.info("    tmpdem {t}".format(t=tmpdem))
-    logging.info("    pixsize {p}".format(p=pixsize))
+    logging.info(f"    tmpdem {tmpdem}")
+    logging.info(f"    pixsize {pixsize}")
     logging.info(f"    bounds: x_min {x_min}; y_min {y_min}; x_max {x_max}; y_max {y_max}")
 
     # xform bounds to projection of the DEM
@@ -416,7 +411,7 @@ def get_dem(x_min,y_min,x_max,y_max,outfile,post=None,processes=1,demName=None,l
     # Also, need to convert from pixel as area to pixel as point
     if "NED" in demname:
         logging.info("Converting to WGS84")
-        gdal.Warp("temp_dem_wgs84.tif",tmpdem, dstSRS="EPSG:4326")
+        gdal.Warp("temp_dem_wgs84.tif", tmpdem, dstSRS="EPSG:4326")
         logging.info("Converting to pixel as point")
         x1, y1, t1, p1, data = \
             saa.read_gdal_file(saa.open_gdal_file("temp_dem_wgs84.tif"))
@@ -426,23 +421,23 @@ def get_dem(x_min,y_min,x_max,y_max,outfile,post=None,processes=1,demName=None,l
         lat = t1[3]
         roty = t1[4]
         resy = t1[5]
-        lon = lon + resx/2.0
-        lat = lat + resy/2.0
+        lon = lon + resx / 2.0
+        lat = lat + resy / 2.0
         t1 = [lon, resx, rotx, lat, roty, resy]
-        saa.write_gdal_file_float(tmpdem,t1,p1,data)
+        saa.write_gdal_file_float(tmpdem, t1, p1, data)
         if not leave:
             os.remove("temp_dem_wgs84.tif")
 
-    clean_dem(tmpdem,tmpdem2)
-    shutil.move(tmpdem2,tmpdem)
-    gdal.Translate(tmpdem2,tmpdem,metadataOptions = ['AREA_OR_POINT=Point'])
-    shutil.move(tmpdem2,tmpdem)
+    clean_dem(tmpdem, tmpdem2)
+    shutil.move(tmpdem2, tmpdem)
+    gdal.Translate(tmpdem2, tmpdem, metadataOptions=['AREA_OR_POINT=Point'])
+    shutil.move(tmpdem2, tmpdem)
 
     # Reproject the DEM file into UTM space
     if demproj != outproj_num:
-        logging.info("Translating raster file to projected coordinates ({p})".format(p=outproj))
-        gdal.Warp(tmpproj,tmpdem,dstSRS=outproj,xRes=pixsize,yRes=pixsize,resampleAlg="cubic",
-                  srcNodata=-32767,dstNodata=-32767)
+        logging.info(f"Translating raster file to projected coordinates ({outproj})")
+        gdal.Warp(tmpproj, tmpdem, dstSRS=outproj, xRes=pixsize, yRes=pixsize, resampleAlg="cubic",
+                  srcNodata=-32767, dstNodata=-32767)
         infile = tmpproj
     else:
         infile = tmpdem
@@ -450,56 +445,64 @@ def get_dem(x_min,y_min,x_max,y_max,outfile,post=None,processes=1,demName=None,l
     report_min(infile)
 
     # Snap to posting grid
-    if  post:
-        snap_to_grid(post,pixsize,infile,outfile)
+    if post:
+        snap_to_grid(post, pixsize, infile, outfile)
     else:
-        shutil.copy(infile,outfile)
+        shutil.copy(infile, outfile)
 
     report_min(outfile)
 
     # Clean up intermediate files
     if not leave:
         if os.path.isfile(tmpdem):
-            logging.info("Removing temp file {}".format(tmpdem))
+            logging.info(f"Removing temp file {tmpdem}")
             os.remove(tmpdem)
         if os.path.isfile(tmpproj):
-            logging.info("Removing temp file {}".format(tmpproj))
+            logging.info(f"Removing temp file {tmpproj}")
             os.remove(tmpproj)
 
     logging.info("Successful Completion!")
-    return(demname)
-
-def report_min(inDem):
-    (x,y,trans,proj,data) = saa.read_gdal_file(saa.open_gdal_file(inDem))
-    logging.debug("DEM file {} minimum is {}".format(inDem,np.min(data)))
+    return demname
 
 
+def report_min(in_dem):
+    (x, y, trans, proj, data) = saa.read_gdal_file(saa.open_gdal_file(in_dem))
+    logging.debug(f"DEM file {in_dem} minimum is {np.min(data)}")
 
-def clean_dem(inDem,outDem):
-    (x,y,trans,proj,data) = saa.read_gdal_file(saa.open_gdal_file(inDem))
+
+def clean_dem(in_dem, out_dem):
+    (x, y, trans, proj, data) = saa.read_gdal_file(saa.open_gdal_file(in_dem))
     logging.info("Replacing values less than -1000 with zero")
-    data[data<=-1000] = -32767
-    logging.info("DEM Maximum value: {}".format(np.max(data)))
-    logging.info("DEM minimum value: {}".format(np.min(data)))
+    data[data <= -1000] = -32767
+    logging.info(f"DEM Maximum value: {np.max(data)}")
+    logging.info(f"DEM minimum value: {np.min(data)}")
 
     if data.dtype == np.float32:
-        saa.write_gdal_file_float(outDem,trans,proj,data.astype(np.float32))
+        saa.write_gdal_file_float(out_dem, trans, proj, data.astype(np.float32))
     elif data.dtype == np.uint16:
-        saa.write_gdal_file(outDem,trans,proj,data)
+        saa.write_gdal_file(out_dem, trans, proj, data)
     else:
-        logging.error("ERROR: Unknown DEM data type {}".format(data.dtype))
-        exit(1)
+        logging.error(f"ERROR: Unknown DEM data type {data.dtype}")
+        sys.exit(1)
+
 
 def snap_to_grid(post, pixsize, infile, outfile):
     if post:
         logging.info("Snapping file to grid at %s meters" % post)
-        (e_min,e_max,n_min,n_max) = get_cc(infile,post,pixsize)
-        bounds = [e_min,n_min,e_max,n_max]
-        gdal.Warp(outfile,infile,xRes=pixsize,yRes=pixsize,outputBounds=bounds,resampleAlg="cubic",dstNodata=-32767)
+        (e_min, e_max, n_min, n_max) = get_cc(infile, post)
+        bounds = [e_min, n_min, e_max, n_max]
+        gdal.Warp(outfile, infile, xRes=pixsize, yRes=pixsize, outputBounds=bounds, resampleAlg="cubic",
+                  dstNodata=-32767)
     else:
         logging.info("Copying DEM to output file name")
-        shutil.copy(infile,outfile)
+        shutil.copy(infile, outfile)
 
+
+def positive_int(value):
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(f"{value} is an invalid positive int value")
+    return ivalue
 
 
 def main():
@@ -523,25 +526,19 @@ def main():
     parser.add_argument("-k", "--keep", action='store_true', help="Keep intermediate DEM results")
     args = parser.parse_args()
 
-    logFile = "get_dem_{}.log".format(os.getpid())
-    logging.basicConfig(filename=logFile, format='%(asctime)s - %(levelname)s - %(message)s',
+    log_file = f"get_dem_{os.getpid()}.log"
+    logging.basicConfig(filename=log_file, format='%(asctime)s - %(levelname)s - %(message)s',
                         datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.DEBUG)
     logging.getLogger().addHandler(logging.StreamHandler())
     logging.info("Starting run")
 
-    y_min = float(args.y_min)
-    y_max = float(args.y_max)
-    x_min = float(args.x_min)
-    x_max = float(args.x_max)
-    outfile = args.outfile
-
     if args.latlon:
-        get_ll_dem(x_min, y_min, x_max, y_max, outfile, post=args.posting,
-                   leave=args.keep, processes=args.threads, demName=args.dem)
+        get_ll_dem(args.x_min, args.y_min, args.x_max, args.y_max, args.outfile, post=args.posting,
+                   leave=args.keep, processes=args.threads, dem_name=args.dem)
 
     else:
-        get_dem(x_min, y_min, x_max, y_max, outfile, post=args.posting,
-                leave=args.keep, processes=args.threads, demName=args.dem)
+        get_dem(args.x_min, args.y_min, args.x_max, args.y_max, args.outfile, post=args.posting,
+                leave=args.keep, processes=args.threads, dem_name=args.dem)
 
 
 if __name__ == "__main__":

--- a/hyp3lib/get_dem.py
+++ b/hyp3lib/get_dem.py
@@ -527,12 +527,12 @@ def main():
     logging.info("Starting run")
 
     if args.latlon:
-        get_ll_dem(args.x_min, args.y_min, args.x_max, args.y_max, args.outfile, post=args.posting,
-                   leave=args.keep, processes=args.threads, dem_name=args.dem)
-
+        dem_type = 'latlon'
     else:
-        get_dem(args.x_min, args.y_min, args.x_max, args.y_max, args.outfile, post=args.posting,
-                leave=args.keep, processes=args.threads, dem_name=args.dem)
+        dem_type = 'utm'
+
+    get_dem(args.x_min, args.y_min, args.x_max, args.y_max, args.outfile, post=args.posting,
+                   leave=args.keep, processes=args.threads, dem_name=args.dem, dem_type=dem_type)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* eliminates most linting errors
* moves format and %s strings to f-strings
* removes the `get_ll_dem` and `get_isce_dem` functions in favor of a new `dem_type=` keyword argument to `get_dem`
* reworks `get_cc` and its helper functions to more clearly parse `gdal_info` subprocess return
  *Note: we probably should just use the [gdal.Info](https://gdal.org/python/osgeo.gdal-module.html#Info) python binding