### PR TITLE
Post release cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.0](https://github.com/ASFHyP3/hyp3-lib/compare/v1.4.1...1.5.0)
+## [1.5.0](https://github.com/ASFHyP3/hyp3-lib/compare/v1.4.1...v1.5.0)
 
 ### Added
 * Documented contribution guidelines in `CONTRIBUTING.md`

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -11,7 +11,6 @@ dependencies:
   - pytest-console-scripts
   - pytest-cov
   # For running
-  - boto3
   - gdal
   - imageio
   - importlib_metadata

--- a/setup.py
+++ b/setup.py
@@ -38,15 +38,13 @@ setup(
     python_requires='~=3.6',
 
     install_requires=[
-        'boto3',
-        'botocore',
+        'gdal',
         'imageio',
         'importlib_metadata',
         'lxml',
         'matplotlib',
         'netCDF4',
         'numpy',
-        'gdal',
         'pillow',
         'pyproj~=2.0',
         'pyshp',


### PR DESCRIPTION
* fixes the v1.5.0 diff link in the `CHANGELOG.md`
* v1.5.0 dropped boto (`get_dem.py` refactor) in favor of requests, an so no longer needs to be listed as a requirement