### PR TITLE
set NUM_THREADS=ALL_CPUS for faster COG compression

### DIFF
--- a/hyp3lib/make_cogs.py
+++ b/hyp3lib/make_cogs.py
@@ -32,7 +32,7 @@ def cogify_file(filename: str):
         filename: GeoTIFF file to convert
     """
     logging.info(f'Converting {filename} to COG')
-    creation_options = ['TILED=YES', 'COMPRESS=DEFLATE']
+    creation_options = ['TILED=YES', 'COMPRESS=DEFLATE', 'NUM_THREADS=ALL_CPUS']
     with NamedTemporaryFile() as temp_file:
         shutil.copy(filename, temp_file.name)
         gdal.Translate(filename, temp_file.name, format='GTiff', creationOptions=creation_options, noData=0)


### PR DESCRIPTION
Option is documented at https://gdal.org/drivers/raster/gtiff.html#open-options

We already leverage this option in the `make_composite` tool at https://github.com/ASFHyP3/asf-tools/blob/develop/asf_tools/composite.py#L215 (although that's technically the `COG` driver, not the `GTiff` driver)

WIthout this option, cog-ifying a 10m RTC product can take up to 3 minutes *per tiff*.