### PR TITLE
Refactor DEM interface via global VRTs for Copernicus 30m and SRTMGL1 30m

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -15,6 +15,7 @@ dependencies:
   - gdal
   - imageio
   - importlib_metadata
+  - jinja2
   - lxml
   - matplotlib
   - netCDF4

--- a/hyp3lib/dem.py
+++ b/hyp3lib/dem.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import jinja2
 from lxml import etree

--- a/hyp3lib/dem.py
+++ b/hyp3lib/dem.py
@@ -14,6 +14,30 @@ gdal.UseExceptions()
 ogr.UseExceptions()
 
 
+def build_geojson(info_list):
+    features = [
+        {
+            "type": "Feature",
+            "properties": {},
+            "id": 0,
+            "geometry": tile['wgs84Extent']
+        }
+        for tile in info_list
+    ]
+
+    geojson = {
+        "type": "FeatureCollection",
+        "crs": {
+            "type": "name",
+            "properties": {
+                "name": "EPSG:4326"
+            }
+        },
+        "features": features
+    }
+    return geojson
+
+
 def build_vrt(info_list):
     pixel_width = min([abs(item['geoTransform'][1]) for item in info_list])
     pixel_height = min([abs(item['geoTransform'][5]) for item in info_list])

--- a/hyp3lib/dem.py
+++ b/hyp3lib/dem.py
@@ -19,23 +19,23 @@ ogr.UseExceptions()
 def build_geojson(gdal_info: List[dict]) -> dict:
     features = [
         {
-            "type": "Feature",
-            "properties": {},
-            "id": 0,
-            "geometry": tile['wgs84Extent']
+            'type': 'Feature',
+            'properties': {},
+            'id': 0,
+            'geometry': tile['wgs84Extent']
         }
         for tile in gdal_info
     ]
 
     geojson = {
-        "type": "FeatureCollection",
-        "crs": {
-            "type": "name",
-            "properties": {
-                "name": "EPSG:4326"
+        'type': 'FeatureCollection',
+        'crs': {
+            'type': 'name',
+            'properties': {
+                'name': 'EPSG:4326'
             }
         },
-        "features": features
+        'features': features
     }
     return geojson
 

--- a/hyp3lib/dem.py
+++ b/hyp3lib/dem.py
@@ -47,16 +47,14 @@ def build_vrt(gdal_info: List[dict]) -> str:
     max_x = max([item['cornerCoordinates']['lowerRight'][0] for item in gdal_info])
     min_y = min([item['cornerCoordinates']['lowerRight'][1] for item in gdal_info])
     max_y = max([item['geoTransform'][3] for item in gdal_info])
-    raster_width = round((max_x - min_x) / pixel_width + 1)
-    raster_height = round((max_y - min_y) / pixel_height + 1)
 
     payload = {
         'pixel_width': pixel_width,
         'pixel_height': pixel_height,
         'min_x': min_x,
         'max_y': max_y,
-        'raster_width': raster_width,
-        'raster_height': raster_height,
+        'raster_width': round((max_x - min_x) / pixel_width + 1),
+        'raster_height': round((max_y - min_y) / pixel_height + 1),
         # assumed to be the same across all tiles
         'projection_wkt': gdal_info[0]['coordinateSystem']['wkt'].replace('\n', ''),
         'axis_mapping': gdal_info[0]['coordinateSystem']['dataAxisToSRSAxisMapping'],

--- a/hyp3lib/dem.py
+++ b/hyp3lib/dem.py
@@ -156,17 +156,16 @@ def utm_from_lon_lat(lon: float, lat: float) -> int:
     return hemisphere + zone
 
 
-def subset_dem(polygon: ogr.Geometry, output_file: str, dem_name: str, epsg_code: Optional[int] = None,
-               buffer: float = 0.15, pixel_size: float = 30.0) -> str:
+def subset_dem(polygon: ogr.Geometry, output_file: str, dem_name: str, buffer: float = 0.15,
+               pixel_size: float = 30.0) -> str:
     dem_list = get_dem_list()
     vrt = [dem['vrt'] for dem in dem_list if dem['name'] == dem_name][0]
 
     min_x, max_x, min_y, max_y = polygon.Buffer(buffer).GetEnvelope()
     output_bounds = (min_x, min_y, max_x, max_y)
 
-    if epsg_code is None:
-        centroid = polygon.Centroid()
-        epsg_code = utm_from_lon_lat(centroid.GetX(), centroid.GetY())
+    centroid = polygon.Centroid()
+    epsg_code = utm_from_lon_lat(centroid.GetX(), centroid.GetY())
 
     gdal.Warp(output_file, vrt, outputBounds=output_bounds, outputBoundsSRS='EPSG:4326', dstSRS=f'EPSG:{epsg_code}',
               xRes=pixel_size, yRes=pixel_size, targetAlignedPixels=True, resampleAlg='cubic', multithread=True)

--- a/hyp3lib/dem.py
+++ b/hyp3lib/dem.py
@@ -58,7 +58,6 @@ def get_best_dem(y_min, y_max, x_min, x_max, threshold=0.2):
     if best_pct < threshold:
         raise DemError('Unable to find a DEM file for that area')
 
-    logging.info(f'Best DEM: {best_dem}')
     return best_dem
 
 

--- a/hyp3lib/dem.py
+++ b/hyp3lib/dem.py
@@ -1,0 +1,82 @@
+"""Get a DEM file in .tif format from the ASF DEM heap"""
+
+import json
+import logging
+from pathlib import Path
+
+from osgeo import gdal, ogr
+
+import hyp3lib.etc
+from hyp3lib import DemError
+
+gdal.UseExceptions()
+ogr.UseExceptions()
+
+
+def get_dem_list():
+    try:
+        config_file = Path.home() / '.hyp3' / 'dems.json'
+        with open(config_file) as f:
+            dem_list = json.load(f)
+    except FileNotFoundError:
+        config_file = Path(hyp3lib.etc.__file__).parent / 'config' / 'dems.json'
+        with open(config_file) as f:
+            dem_list = json.load(f)
+    return dem_list
+
+
+def get_coverage_geometry(coverage_geojson):
+    ds = ogr.Open(coverage_geojson)
+    layer = ds.GetLayer()
+    geom = None
+    for feature in layer:
+        geom = feature.GetGeometryRef()
+        break
+    del ds
+    return ogr.CreateGeometryFromWkt(geom.ExportToWkt())
+
+
+def get_best_dem(y_min, y_max, x_min, x_max, threshold=0.2):
+    dem_list = get_dem_list()
+    wkt = f'POLYGON(({x_min} {y_min}, {x_max} {y_min}, {x_max} {y_max}, {x_min} {y_max}, {x_min} {y_min}))'
+    polygon = ogr.CreateGeometryFromWkt(wkt)
+
+    best_pct = 0
+    best_dem = ''
+    for dem in dem_list:
+        coverage = get_coverage_geometry(dem['coverage'])
+
+        covered_area = polygon.Intersection(coverage).GetArea()
+        total_area = polygon.GetArea()
+        pct = covered_area / total_area
+        logging.info(f"{dem['name']}: {pct*100:.2f}% coverage ({covered_area:.2f}/{total_area:.2f})")
+
+        if best_pct == 0 or pct > best_pct + 0.05:
+            best_pct = pct
+            best_dem = dem['name']
+
+    if best_pct < threshold:
+        raise DemError('Unable to find a DEM file for that area')
+
+    logging.info(f'Best DEM: {best_dem}')
+    return best_dem
+
+
+def utm_from_lat_lon(lat, lon):
+    hemisphere = 32600 if lat >= 0 else 32700
+    zone = (lon // 6 + 30) % 60 + 1
+    return hemisphere + zone
+
+
+def get_dem(outfile, dem_name, y_min, y_max, x_min, x_max, buffer=0.0, res=30.0):
+    dem_list = get_dem_list()
+    vrt = [dem['vrt'] for dem in dem_list if dem['name'] == dem_name][0]
+    output_bounds = [x_min - buffer, y_min - buffer, x_max + buffer, y_max + buffer]
+    epsg_code = utm_from_lat_lon((y_min + y_max) / 2, (x_min + x_max) / 2)
+
+    gdal.Warp(outfile, vrt, outputBounds=output_bounds, outputBoundsSRS='EPSG:4326', dstSRS=f'EPSG:{epsg_code}',
+              xRes=res, yRes=res, targetAlignedPixels=True, resampleAlg='cubic', dstNodata=-32767, multithread=True)
+
+    #TODO pixel as point?
+
+    return outfile

--- a/hyp3lib/etc/config/dems.json
+++ b/hyp3lib/etc/config/dems.json
@@ -1,12 +1,10 @@
-[
-  {
-    "name": "COP30",
-    "coverage": "/vsis3/asj-hyp3-dev/dems/cop_coverage.geojson",
-    "vrt": "/vsis3/asj-hyp3-dev/dems/cop30.vrt"
+{
+  "COP30": {
+    "coverage": "/vsis3/asf-dem-west/cop_coverage.geojson",
+    "vrt": "/vsis3/asf-dem-west/cop30.vrt"
   },
-  {
-    "name": "SRTMGL1",
+  "SRTMGL1": {
     "coverage": "/vsis3/asj-hyp3-dev/dems/srtmgl1_coverage.geojson",
     "vrt": "/vsis3/asj-hyp3-dev/dems/srtmgl1.vrt"
   }
-]
+}

--- a/hyp3lib/etc/config/dems.json
+++ b/hyp3lib/etc/config/dems.json
@@ -1,10 +1,10 @@
 {
   "COP30": {
-    "coverage": "/vsis3/asf-dem-west/cop_coverage.geojson",
-    "vrt": "/vsis3/asf-dem-west/cop30.vrt"
+    "coverage": "/vsis3/asf-dem-west/v2/cop_coverage.geojson",
+    "vrt": "/vsis3/asf-dem-west/v2/cop30.vrt"
   },
   "SRTMGL1": {
-    "coverage": "/vsis3/asj-hyp3-dev/dems/srtmgl1_coverage.geojson",
-    "vrt": "/vsis3/asj-hyp3-dev/dems/srtmgl1.vrt"
+    "coverage": "/vsis3/asf-dem-west/v2/srtmgl1_coverage.geojson",
+    "vrt": "/vsis3/asf-dem-west/v2/srtmgl1.vrt"
   }
 }

--- a/hyp3lib/etc/config/dems.json
+++ b/hyp3lib/etc/config/dems.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "SRTMGL1",
+    "coverage": "/vsis3/asj-hyp3-dev/dems/srtmgl1_coverage.geojson",
+    "vrt": "/vsis3/asj-hyp3-dev/dems/srtmgl1.vrt"
+  },
+  {
+    "name": "NED13",
+    "coverage": "/vsis3/asj-hyp3-dev/dems/ned13_coverage.geojson",
+    "vrt": "/vsis3/asj-hyp3-dev/dems/ned13.vrt"
+  },
+  {
+    "name": "COP30",
+    "coverage": "/vsis3/asj-hyp3-dev/dems/cop_coverage.geojson",
+    "vrt": ""
+  }
+]

--- a/hyp3lib/etc/config/dems.json
+++ b/hyp3lib/etc/config/dems.json
@@ -1,17 +1,12 @@
 [
   {
-    "name": "SRTMGL1",
-    "coverage": "/vsis3/asj-hyp3-dev/dems/srtmgl1_coverage.geojson",
-    "vrt": "/vsis3/asj-hyp3-dev/dems/srtmgl1.vrt"
-  },
-  {
-    "name": "NED13",
-    "coverage": "/vsis3/asj-hyp3-dev/dems/ned13_coverage.geojson",
-    "vrt": "/vsis3/asj-hyp3-dev/dems/ned13.vrt"
-  },
-  {
     "name": "COP30",
     "coverage": "/vsis3/asj-hyp3-dev/dems/cop_coverage.geojson",
     "vrt": "/vsis3/asj-hyp3-dev/dems/cop30.vrt"
+  },
+  {
+    "name": "SRTMGL1",
+    "coverage": "/vsis3/asj-hyp3-dev/dems/srtmgl1_coverage.geojson",
+    "vrt": "/vsis3/asj-hyp3-dev/dems/srtmgl1.vrt"
   }
 ]

--- a/hyp3lib/etc/config/dems.json
+++ b/hyp3lib/etc/config/dems.json
@@ -1,6 +1,6 @@
 {
   "COP30": {
-    "coverage": "/vsis3/asf-dem-west/v2/cop_coverage.geojson",
+    "coverage": "/vsis3/asf-dem-west/v2/cop30_coverage.geojson",
     "vrt": "/vsis3/asf-dem-west/v2/cop30.vrt"
   },
   "SRTMGL1": {

--- a/hyp3lib/etc/config/dems.json
+++ b/hyp3lib/etc/config/dems.json
@@ -12,6 +12,6 @@
   {
     "name": "COP30",
     "coverage": "/vsis3/asj-hyp3-dev/dems/cop_coverage.geojson",
-    "vrt": ""
+    "vrt": "/vsis3/asj-hyp3-dev/dems/cop30.vrt"
   }
 ]

--- a/hyp3lib/etc/config/get_dem.cfg
+++ b/hyp3lib/etc/config/get_dem.cfg
@@ -1,5 +1,5 @@
-NED13 https://asf-dem-west.s3.amazonaws.com/NED13/ 4269
 SRTMGL1 https://asf-dem-west.s3.amazonaws.com/SRTMGL1/ 4326
+NED13 https://asf-dem-west.s3.amazonaws.com/NED13/ 4269
 NED1 https://asf-dem-west.s3.amazonaws.com/NED1/ 4269
 NED2 https://asf-dem-west.s3.amazonaws.com/NED2/ 4269
 SRTMGL3 https://asf-dem-west.s3.amazonaws.com/SRTMGL3/ 4326

--- a/hyp3lib/etc/config/get_dem.cfg
+++ b/hyp3lib/etc/config/get_dem.cfg
@@ -1,5 +1,5 @@
-SRTMGL1 https://asf-dem-west.s3.amazonaws.com/SRTMGL1/ 4326
 NED13 https://asf-dem-west.s3.amazonaws.com/NED13/ 4269
+SRTMGL1 https://asf-dem-west.s3.amazonaws.com/SRTMGL1/ 4326
 NED1 https://asf-dem-west.s3.amazonaws.com/NED1/ 4269
 NED2 https://asf-dem-west.s3.amazonaws.com/NED2/ 4269
 SRTMGL3 https://asf-dem-west.s3.amazonaws.com/SRTMGL3/ 4326

--- a/hyp3lib/etc/vrt.j2
+++ b/hyp3lib/etc/vrt.j2
@@ -1,0 +1,22 @@
+<VRTDataset rasterXSize="{{ raster_width }}" rasterYSize="{{ raster_height }}">
+  <SRS dataAxisToSRSAxisMapping="{{ axis_mapping[0] }},{{ axis_mapping[1] }}">{{ projection_wkt }}</SRS>
+  <GeoTransform>{{ min_x }}, {{ pixel_width }}, 0.0, {{ max_y }}, 0.0, -{{ pixel_height }}</GeoTransform>
+  <Metadata>
+    <MDI key="AREA_OR_POINT">{{ area_or_point }}</MDI>
+  </Metadata>
+  <VRTRasterBand dataType="{{ data_type }}" band="1">
+    <ColorInterp>{{ color_interp }}</ColorInterp>
+    {% if no_data_value %}
+    <NoDataValue>{{ no_data_value }}</NoDataValue>
+    {% endif %}
+    {% for tile in tiles %}
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{{ tile['location'] }}</SourceFilename>
+      <SourceBand>{{ tile.source_band }}</SourceBand>
+      <SourceProperties RasterXSize="{{ tile['width'] }}" RasterYSize="{{ tile['height'] }}" DataType="{{ data_type }}" BlockXSize="{{ tile['block_size'][0] }}" BlockYSize="{{ tile['block_size'][1] }}" />
+      <SrcRect xOff="0" yOff="0" xSize="{{ tile['width'] }}" ySize="{{ tile['height'] }}" />
+      <DstRect xOff="{{ tile['x_offset'] }}" yOff="{{ tile['y_offset'] }}" xSize="{{ tile['dst_width'] }}" ySize="{{ tile['dst_height'] }}" />
+    </SimpleSource>
+    {% endfor %}
+  </VRTRasterBand>
+</VRTDataset>

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'gdal',
         'imageio',
         'importlib_metadata',
+        'jinja2',
         'lxml',
         'matplotlib',
         'netCDF4',

--- a/tests/data/test.SAFE/manifest.safe
+++ b/tests/data/test.SAFE/manifest.safe
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xfdu:XFDU xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xmlns:xfdu="urn:ccsds:schema:xfdu:1" xmlns:safe="http://www.esa.int/safe/sentinel-1.0" xmlns:s1="http://www.esa.int/safe/sentinel-1.0/sentinel-1" xmlns:s1sar="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar" xmlns:s1sarl1="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-1" xmlns:s1sarl2="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-2" xmlns:gx="http://www.google.com/kml/ext/2.2" version="esa/safe/sentinel-1.0/sentinel-1/sar/level-1/slc/standard/iwsp">
+  <informationPackageMap>
+    <xfdu:contentUnit unitType="SAFE Archive Information Package" textInfo="Sentinel-1 IW Level-1 SLC Product" dmdID="acquisitionPeriod platform generalProductInformation measurementOrbitReference measurementFrameSet" pdiID="processing">
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw1slcvv20150516t13342120150516t133446005947007a98001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw1slcvv20150516t13342120150516t133446005947007a98001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw1slcvv20150516t13342120150516t133446005947007a98001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw2slcvv20150516t13342020150516t133447005947007a98002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw2slcvv20150516t13342020150516t133447005947007a98002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw2slcvv20150516t13342020150516t133447005947007a98002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw3slcvv20150516t13342020150516t133446005947007a98003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw3slcvv20150516t13342020150516t133446005947007a98003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw3slcvv20150516t13342020150516t133446005947007a98003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1MapOverlaySchema">
+        <dataObjectPointer dataObjectID="mapoverlay"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductPreviewSchema">
+        <dataObjectPointer dataObjectID="productpreview"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw1slcvv20150516t13342120150516t133446005947007a98001Annotation noises1aiw1slcvv20150516t13342120150516t133446005947007a98001Annotation calibrations1aiw1slcvv20150516t13342120150516t133446005947007a98001Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw1slcvv20150516t13342120150516t133446005947007a98001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw2slcvv20150516t13342020150516t133447005947007a98002Annotation noises1aiw2slcvv20150516t13342020150516t133447005947007a98002Annotation calibrations1aiw2slcvv20150516t13342020150516t133447005947007a98002Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw2slcvv20150516t13342020150516t133447005947007a98002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw3slcvv20150516t13342020150516t133446005947007a98003Annotation noises1aiw3slcvv20150516t13342020150516t133446005947007a98003Annotation calibrations1aiw3slcvv20150516t13342020150516t133446005947007a98003Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw3slcvv20150516t13342020150516t133446005947007a98003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1QuickLookSchema">
+        <dataObjectPointer dataObjectID="quicklook"/>
+      </xfdu:contentUnit>
+    </xfdu:contentUnit>
+  </informationPackageMap>
+  <metadataSection>
+    <metadataObject ID="products1aiw1slcvv20150516t13342120150516t133446005947007a98001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw1slcvv20150516t13342120150516t133446005947007a98001"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw1slcvv20150516t13342120150516t133446005947007a98001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw1slcvv20150516t13342120150516t133446005947007a98001"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw1slcvv20150516t13342120150516t133446005947007a98001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw1slcvv20150516t13342120150516t133446005947007a98001"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw2slcvv20150516t13342020150516t133447005947007a98002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw2slcvv20150516t13342020150516t133447005947007a98002"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw2slcvv20150516t13342020150516t133447005947007a98002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw2slcvv20150516t13342020150516t133447005947007a98002"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw2slcvv20150516t13342020150516t133447005947007a98002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw2slcvv20150516t13342020150516t133447005947007a98002"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw3slcvv20150516t13342020150516t133446005947007a98003Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw3slcvv20150516t13342020150516t133446005947007a98003"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw3slcvv20150516t13342020150516t133446005947007a98003Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw3slcvv20150516t13342020150516t133446005947007a98003"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw3slcvv20150516t13342020150516t133446005947007a98003Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw3slcvv20150516t13342020150516t133446005947007a98003"/>
+    </metadataObject>
+    <metadataObject ID="mapoverlayAnnotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="mapoverlay"/>
+    </metadataObject>
+    <metadataObject ID="productpreviewAnnotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="productpreview"/>
+    </metadataObject>
+    <metadataObject ID="processing" classification="PROVENANCE" category="PDI">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Processing">
+        <xmlData>
+          <safe:processing name="SLC Post Processing" start="2015-05-16T16:08:26.936799" stop="2015-05-16T16:13:21.000000">
+            <safe:facility country="Germany" name="DPA_" organisation="DLR" site="Oberpfaffenhofen">
+              <safe:software name="Sentinel-1 IPF" version="002.43"/>
+            </safe:facility>
+            <safe:resource name="S1A_IW_SL1__1_SV_20150516T133420_20150516T133450_005947_007A98_1099.SAFE" role="Level-1 Intermediate SLC Product">
+              <processing name="SLC Processing" start="2015-05-16T16:10:09.000000" stop="2015-05-16T16:12:27.000000" xmlns="http://www.esa.int/safe/sentinel-1.0">
+                <facility country="Germany" name="DPA_" organisation="DLR" site="Oberpfaffenhofen">
+                  <software name="Sentinel-1 IPF" version="002.43"/>
+                </facility>
+                <resource name="/data/localWD/483386077//S1A_AUX_PP1_V20140915T100000_G20150512T085624.SAFE" role="AUX_PP1"/>
+                <resource name="/data/localWD/483386077//S1A_AUX_CAL_V20140915T100000_G20150504T152619.SAFE" role="AUX_CAL"/>
+                <resource name="/data/localWD/483386077//S1A_AUX_INS_V20140915T100000_G20150511T155419.SAFE" role="AUX_INS"/>
+                <resource name="/data/localWD/483386077//S1A_OPER_AUX_RESORB_OPOD_20150516T153233_V20150516T111642_20150516T143412.EOF" role="AUX_RES"/>
+                <resource name="/data/localWD/483386077//S1A_IW_RAW__0SSV_20150516T133417_20150516T133450_005947_007A98_79DA.SAFE" role="Level-0 Product">
+                  <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Generation of Sentinel-1 SAR Slice L0 product" start="2015-05-16T15:53:04.206227" stop="2015-05-16T15:53:05.384589">
+                    <facility country="Germany" name="DPA_" organisation="DLR" site="Oberpfaffenhofen">
+                      <software name="" version=""/>
+                    </facility>
+                    <resource name="S-1 Core PDGS S-1 Level-0 Product Format Specifications S1PD.SP.00110.ASTR" role="Applicable Document"/>
+                    <resource name="Sentinel-1 SAR Space Packet Protocol Data Unit S1-IF-ASD-PL-0007" role="Applicable Document" version="10"/>
+                    <resource name="Downlinked Stream" role="Raw Data">
+                      <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Raw Data Downlink Channel2" start="2015-05-16T14:53:26.106322" stop="2015-05-16T14:53:51.705454">
+                        </processing>
+                    </resource>
+                  </processing>
+                </resource>
+                <resource name="Sentinel-1 Product Definition (S1-RS-MDA-52-7440) release 2/5" role="product definition"/>
+                <resource name="Sentinel-1 Product Specification (S1-RS-MDA-52-7441) release 2/9" role="product specification"/>
+              </processing>
+            </safe:resource>
+          </safe:processing>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="platform" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Platform Description">
+        <xmlData>
+          <safe:platform>
+            <safe:nssdcIdentifier>0000-000A</safe:nssdcIdentifier>
+            <safe:familyName>SENTINEL-1</safe:familyName>
+            <safe:number>A</safe:number>
+            <safe:instrument>
+              <safe:familyName abbreviation="SAR">Synthetic Aperture Radar</safe:familyName>
+              <safe:extension>
+                <s1sarl1:instrumentMode>
+                  <s1sarl1:mode>IW</s1sarl1:mode>
+                  <s1sarl1:swath>IW1</s1sarl1:swath>
+                  <s1sarl1:swath>IW2</s1sarl1:swath>
+                  <s1sarl1:swath>IW3</s1sarl1:swath>
+                </s1sarl1:instrumentMode>
+              </safe:extension>
+            </safe:instrument>
+          </safe:platform>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="measurementOrbitReference" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Orbit Reference">
+        <xmlData>
+          <safe:orbitReference>
+            <safe:orbitNumber type="start">5947</safe:orbitNumber>
+            <safe:orbitNumber type="stop">5947</safe:orbitNumber>
+            <safe:relativeOrbitNumber type="start">100</safe:relativeOrbitNumber>
+            <safe:relativeOrbitNumber type="stop">100</safe:relativeOrbitNumber>
+            <safe:cycleNumber>48</safe:cycleNumber>
+            <safe:phaseIdentifier>1</safe:phaseIdentifier>
+            <safe:extension>
+              <s1:orbitProperties>
+                <s1:pass>DESCENDING</s1:pass>
+                <s1:ascendingNodeTime>2015-05-16T12:55:32.227393</s1:ascendingNodeTime>
+              </s1:orbitProperties>
+            </safe:extension>
+          </safe:orbitReference>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="generalProductInformation" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="General Product Information">
+        <xmlData>
+          <s1sarl1:standAloneProductInformation>
+            <s1sarl1:instrumentConfigurationID>3</s1sarl1:instrumentConfigurationID>
+            <s1sarl1:missionDataTakeID>31384</s1sarl1:missionDataTakeID>
+            <s1sarl1:transmitterReceiverPolarisation>VV</s1sarl1:transmitterReceiverPolarisation>
+            <s1sarl1:productClass>S</s1sarl1:productClass>
+            <s1sarl1:productClassDescription>SAR Standard L1 Product</s1sarl1:productClassDescription>
+            <s1sarl1:productComposition>Slice</s1sarl1:productComposition>
+            <s1sarl1:productType>SLC</s1sarl1:productType>
+            <s1sarl1:productTimelinessCategory>Fast-24h</s1sarl1:productTimelinessCategory>
+            <s1sarl1:sliceProductFlag>true</s1sarl1:sliceProductFlag>
+            <s1sarl1:segmentStartTime>2015-05-16T13:31:22.869987</s1sarl1:segmentStartTime>
+            <s1sarl1:sliceNumber>8</s1sarl1:sliceNumber>
+            <s1sarl1:totalSlices>12</s1sarl1:totalSlices>
+          </s1sarl1:standAloneProductInformation>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="acquisitionPeriod" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Acquisition Period">
+        <xmlData>
+          <safe:acquisitionPeriod>
+            <safe:startTime>2015-05-16T13:34:20.002947</safe:startTime>
+            <safe:stopTime>2015-05-16T13:34:47.929735</safe:stopTime>
+            <safe:extension>
+              <s1:timeANX>
+                <s1:startTimeANX>2.327776e+06</s1:startTimeANX>
+                <s1:stopTimeANX>2.355702e+06</s1:stopTimeANX>
+              </s1:timeANX>
+            </safe:extension>
+          </safe:acquisitionPeriod>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="measurementFrameSet" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Frame Set">
+        <xmlData>
+          <safe:frameSet>
+            <safe:frame>
+              <safe:footPrint srsName="http://www.opengis.net/gml/srs/epsg.xml#4326">
+                <gml:coordinates>37.063725,-111.577644 37.459259,-114.392342 39.136841,-114.048729 38.742691,-111.166084</gml:coordinates>
+              </safe:footPrint>
+            </safe:frame>
+          </safe:frameSet>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="s1Level1ProductSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-product.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1NoiseSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-noise.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1CalibrationSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-calibration.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1ObjectTypesSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-object-types.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1MeasurementSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="SDF" locatorType="URL" href="./support/s1-level-1-measurement.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1ProductPreviewSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-product-preview.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1QuickLookSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-quicklook.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1MapOverlaySchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-map-overlay.xsd"/>
+    </metadataObject>
+  </metadataSection>
+  <dataObjectSection>
+    <dataObject ID="products1aiw1slcvv20150516t13342120150516t133446005947007a98001" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="862341">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw1-slc-vv-20150516t133421-20150516t133446-005947-007a98-001.xml"/>
+        <checksum checksumName="MD5">5c95661847da6aabdbb451ef020da48d</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw1slcvv20150516t13342120150516t133446005947007a98001" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="112439">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw1-slc-vv-20150516t133421-20150516t133446-005947-007a98-001.xml"/>
+        <checksum checksumName="MD5">83b1da34fbc74295fe076969711cc794</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw1slcvv20150516t13342120150516t133446005947007a98001" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="941336">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw1-slc-vv-20150516t133421-20150516t133446-005947-007a98-001.xml"/>
+        <checksum checksumName="MD5">a5b40ac068cc637109a54d8321727de9</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw2slcvv20150516t13342020150516t133447005947007a98002" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="931377">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw2-slc-vv-20150516t133420-20150516t133447-005947-007a98-002.xml"/>
+        <checksum checksumName="MD5">b74c45efcae634b2161b2de1d3b1e667</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw2slcvv20150516t13342020150516t133447005947007a98002" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="131040">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw2-slc-vv-20150516t133420-20150516t133447-005947-007a98-002.xml"/>
+        <checksum checksumName="MD5">dd41a91691ed5fecb802888e8ea1f225</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw2slcvv20150516t13342020150516t133447005947007a98002" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1111855">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw2-slc-vv-20150516t133420-20150516t133447-005947-007a98-002.xml"/>
+        <checksum checksumName="MD5">80987403aeed3bff606e9a177a492141</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw3slcvv20150516t13342020150516t133446005947007a98003" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="767906">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw3-slc-vv-20150516t133420-20150516t133446-005947-007a98-003.xml"/>
+        <checksum checksumName="MD5">f75ac161639d267352d3482c19462e04</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw3slcvv20150516t13342020150516t133446005947007a98003" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="128114">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw3-slc-vv-20150516t133420-20150516t133446-005947-007a98-003.xml"/>
+        <checksum checksumName="MD5">dc242d6bf86889c37e7b94d73b2f9efd</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw3slcvv20150516t13342020150516t133446005947007a98003" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1071835">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw3-slc-vv-20150516t133420-20150516t133446-005947-007a98-003.xml"/>
+        <checksum checksumName="MD5">bb80097efb272f124da7ed0fce09d10f</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="mapoverlay" repID="s1Level1MapOverlaySchema">
+      <byteStream mimeType="text/xml" size="1026">
+        <fileLocation locatorType="URL" href="./preview/map-overlay.kml"/>
+        <checksum checksumName="MD5">cee82dd2a521f1c88dc8c8e3be319a3d</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="productpreview" repID="s1Level1ProductPreviewSchema">
+      <byteStream mimeType="text/xml" size="3975">
+        <fileLocation locatorType="URL" href="./preview/product-preview.html"/>
+        <checksum checksumName="MD5">a585538748ef8740e4543fa3754ddadc</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw1slcvv20150516t13342120150516t133446005947007a98001" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1162988711">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw1-slc-vv-20150516t133421-20150516t133446-005947-007a98-001.tiff"/>
+        <checksum checksumName="MD5">3e9e86b4dd7dcf02eae09d6771d09edf</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw2slcvv20150516t13342020150516t133447005947007a98002" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1537846915">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw2-slc-vv-20150516t133420-20150516t133447-005947-007a98-002.tiff"/>
+        <checksum checksumName="MD5">512a60c21068be762fc921068d428880</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw3slcvv20150516t13342020150516t133446005947007a98003" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1340560835">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw3-slc-vv-20150516t133420-20150516t133446-005947-007a98-003.tiff"/>
+        <checksum checksumName="MD5">bc53ff8f7a19a493beadc95a637e82ed</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="quicklook" repID="s1Level1QuickLookSchema">
+      <byteStream mimeType="application/octet-stream" size="2125756">
+        <fileLocation locatorType="URL" href="./preview/quick-look.png"/>
+        <checksum checksumName="MD5">dccb712dce946406109b5d51ef10b9c1</checksum>
+      </byteStream>
+    </dataObject>
+  </dataObjectSection>
+</xfdu:XFDU>

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -2,28 +2,34 @@ import json
 
 import pytest
 
-from hyp3lib import DemError
-from hyp3lib.dem import get_best_dem, utm_from_lon_lat, get_coverage_geometry
+from hyp3lib import DemError, dem
 
 
 # def test_get_best_dem():
-#     assert get_best_dem(y_min=37.0, y_max=38.0, x_min=-118.0, x_max=-117.0) == 'COP30'
-#     assert get_best_dem(y_min=-6.8, y_max=-6.2, x_min=27.2, x_max=27.8) == 'SRTMGL1'
-#     assert get_best_dem(y_min=59.975, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
-#     assert get_best_dem(y_min=59.976, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
+#     assert dem.get_best_dem(y_min=37.0, y_max=38.0, x_min=-118.0, x_max=-117.0) == 'COP30'
+#     assert dem.get_best_dem(y_min=-6.8, y_max=-6.2, x_min=27.2, x_max=27.8) == 'SRTMGL1'
+#     assert dem.get_best_dem(y_min=59.975, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
+#     assert dem.get_best_dem(y_min=59.976, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
 #
 #     with pytest.raises(DemError):
-#         get_best_dem(y_min=0, y_max=1, x_min=0, x_max=1)
+#         dem.get_best_dem(y_min=0, y_max=1, x_min=0, x_max=1)
+
+
+def test_get_polygon_from_manifest(test_data_folder):
+    manifest_file = test_data_folder / 'test.SAFE' / 'manifest.safe'
+    polygon = dem.get_polygon_from_manifest(str(manifest_file))
+    assert polygon.ExportToWkt() == 'POLYGON ((-111.577644 37.063725,-114.392342 37.459259,-114.048729 39.136841,' \
+                                    '-111.166084 38.742691,-111.577644 37.063725))'
 
 
 def test_utm_from_lat_lon():
-    assert utm_from_lon_lat(0, 0) == 32631
-    assert utm_from_lon_lat(-179, -1) == 32701
-    assert utm_from_lon_lat(179, 1) == 32660
-    assert utm_from_lon_lat(27, 89) == 32635
-    assert utm_from_lon_lat(182, 1) == 32601
-    assert utm_from_lon_lat(-182, 1) == 32660
-    assert utm_from_lon_lat(-360, -1) == 32731
+    assert dem.utm_from_lon_lat(0, 0) == 32631
+    assert dem.utm_from_lon_lat(-179, -1) == 32701
+    assert dem.utm_from_lon_lat(179, 1) == 32660
+    assert dem.utm_from_lon_lat(27, 89) == 32635
+    assert dem.utm_from_lon_lat(182, 1) == 32601
+    assert dem.utm_from_lon_lat(-182, 1) == 32660
+    assert dem.utm_from_lon_lat(-360, -1) == 32731
 
 
 def test_get_coverage_geometry(tmp_path):
@@ -43,7 +49,7 @@ def test_get_coverage_geometry(tmp_path):
     with open(coverage_file, 'w') as f:
         json.dump(geojson, f)
 
-    geom = get_coverage_geometry(str(coverage_file))
+    geom = dem.get_coverage_geometry(str(coverage_file))
     assert geom.ExportToWkt() == 'POINT (125.6 10.1)'
 
 

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -1,0 +1,73 @@
+import json
+
+import pytest
+
+from hyp3lib import DemError
+from hyp3lib.dem import get_best_dem, utm_from_lat_lon, get_coverage_geometry
+
+
+def test_get_best_dem():
+    # assert get_best_dem(y_min=38.2, y_max=38.8, x_min=-110.8, x_max=-110.2) == 'NED13'
+    assert get_best_dem(y_min=-6.8, y_max=-6.2, x_min=27.2, x_max=27.8) == 'SRTMGL1'
+    # assert get_best_dem(y_min=67.9, y_max=68.1, x_min=-155.6, x_max=-155.4) == 'NED2'
+    assert get_best_dem(y_min=59.975, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
+    assert get_best_dem(y_min=59.976, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
+
+    with pytest.raises(DemError):
+        get_best_dem(y_min=0, y_max=1, x_min=0, x_max=1)
+
+
+def test_utm_from_lat_lon():
+    assert utm_from_lat_lon(0, 0) == 32631
+    assert utm_from_lat_lon(-1, -179) == 32701
+    assert utm_from_lat_lon(1, 179) == 32660
+    assert utm_from_lat_lon(89, 27) == 32635
+    assert utm_from_lat_lon(1, 182) == 32601
+    assert utm_from_lat_lon(1, -182) == 32660
+    assert utm_from_lat_lon(-1, -360) == 32731
+
+
+def test_get_coverage_geometry(tmp_path):
+    coverage_file = tmp_path / 'coverage.geojson'
+    geojson = {
+        "type": "FeatureCollection",
+        'features': [
+            {
+                'type': 'Feature',
+                'geometry': {
+                  'type': 'Point',
+                  'coordinates': [125.6, 10.1],
+                },
+            },
+        ],
+    }
+    with open(coverage_file, 'w') as f:
+        json.dump(geojson, f)
+
+    geom = get_coverage_geometry(str(coverage_file))
+    assert geom.ExportToWkt() == 'POINT (125.6 10.1)'
+
+
+# def test_get_best_dem_antimeridian():
+#     # aleutian islands
+#     name, projection, tile_list, wkt_list = get_best_dem(y_min=51.3, y_max=51.7, x_min=-179.5, x_max=179.5)
+#     assert name == 'SRTMGL1'
+#     assert projection == 4326
+#     assert len(tile_list) == 241
+#     for tile in tile_list:
+#         assert tile.startswith('N51')
+#     assert len(wkt_list) == 241
+#
+#
+# def test_get_best_dem_antimeridian_shifted():
+#     # aleutian islands
+#     name, projection, tile_list, wkt_list = get_best_dem(y_min=51.3, y_max=51.7, x_min=179.5, x_max=180.5)
+#     assert name == 'SRTMGL1'
+#     assert projection == 4326
+#     assert tile_list == ['N51E179', 'N51W180']
+#     assert wkt_list == [
+#         'POLYGON ((178.999861 52.000139,180.000138777786 52.000139,180.000138777786 50.9998612222142,'
+#         '178.999861 50.9998612222142,178.999861 52.000139))',
+#         'POLYGON ((179.999861 52.000139,181.000138777786 52.000139,181.000138777786 50.9998612222142,'
+#         '179.999861 50.9998612222142,179.999861 52.000139))',
+#     ]

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -3,27 +3,27 @@ import json
 import pytest
 
 from hyp3lib import DemError
-from hyp3lib.dem import get_best_dem, utm_from_lat_lon, get_coverage_geometry
+from hyp3lib.dem import get_best_dem, utm_from_lon_lat, get_coverage_geometry
 
 
-def test_get_best_dem():
-    assert get_best_dem(y_min=37.0, y_max=38.0, x_min=-118.0, x_max=-117.0) == 'COP30'
-    assert get_best_dem(y_min=-6.8, y_max=-6.2, x_min=27.2, x_max=27.8) == 'SRTMGL1'
-    assert get_best_dem(y_min=59.975, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
-    assert get_best_dem(y_min=59.976, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
-
-    with pytest.raises(DemError):
-        get_best_dem(y_min=0, y_max=1, x_min=0, x_max=1)
+# def test_get_best_dem():
+#     assert get_best_dem(y_min=37.0, y_max=38.0, x_min=-118.0, x_max=-117.0) == 'COP30'
+#     assert get_best_dem(y_min=-6.8, y_max=-6.2, x_min=27.2, x_max=27.8) == 'SRTMGL1'
+#     assert get_best_dem(y_min=59.975, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
+#     assert get_best_dem(y_min=59.976, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
+#
+#     with pytest.raises(DemError):
+#         get_best_dem(y_min=0, y_max=1, x_min=0, x_max=1)
 
 
 def test_utm_from_lat_lon():
-    assert utm_from_lat_lon(0, 0) == 32631
-    assert utm_from_lat_lon(-1, -179) == 32701
-    assert utm_from_lat_lon(1, 179) == 32660
-    assert utm_from_lat_lon(89, 27) == 32635
-    assert utm_from_lat_lon(1, 182) == 32601
-    assert utm_from_lat_lon(1, -182) == 32660
-    assert utm_from_lat_lon(-1, -360) == 32731
+    assert utm_from_lon_lat(0, 0) == 32631
+    assert utm_from_lon_lat(-179, -1) == 32701
+    assert utm_from_lon_lat(179, 1) == 32660
+    assert utm_from_lon_lat(27, 89) == 32635
+    assert utm_from_lon_lat(182, 1) == 32601
+    assert utm_from_lon_lat(-182, 1) == 32660
+    assert utm_from_lon_lat(-360, -1) == 32731
 
 
 def test_get_coverage_geometry(tmp_path):

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -1,18 +1,34 @@
 import json
 
 import pytest
+from osgeo import ogr
 
 from hyp3lib import DemError, dem
 
 
-# def test_get_best_dem():
-#     assert dem.get_best_dem(y_min=37.0, y_max=38.0, x_min=-118.0, x_max=-117.0) == 'COP30'
-#     assert dem.get_best_dem(y_min=-6.8, y_max=-6.2, x_min=27.2, x_max=27.8) == 'SRTMGL1'
-#     assert dem.get_best_dem(y_min=59.975, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
-#     assert dem.get_best_dem(y_min=59.976, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
-#
-#     with pytest.raises(DemError):
-#         dem.get_best_dem(y_min=0, y_max=1, x_min=0, x_max=1)
+def _get_geometry_from_bbox(south, north, west, east):
+    wkt = f'POLYGON(({west} {south}, {west} {north}, {east} {north}, {east} {south}, {west} {south}))'
+    return ogr.CreateGeometryFromWkt(wkt)
+
+
+def test_get_best_dem():
+    polygon = _get_geometry_from_bbox(37.0, 38.0, -118.0, 117.0)
+    assert dem.get_best_dem(polygon) == 'COP30'
+
+    polygon = _get_geometry_from_bbox(-6.8, -6.2, 27.2, 27.8)
+    assert dem.get_best_dem(polygon) == 'SRTMGL1'
+
+    polygon = _get_geometry_from_bbox(59.975, 60.1, 99.5, 100.5)
+    assert dem.get_best_dem(polygon) == 'COP30'
+
+    polygon = _get_geometry_from_bbox(59.976, 60.1, 99.5, 100.5)
+    assert dem.get_best_dem(polygon) == 'COP30'
+
+    # TODO test threshold parameter
+
+    polygon = _get_geometry_from_bbox(0, 1, 0, 1)
+    with pytest.raises(DemError):
+        dem.get_best_dem(polygon)
 
 
 def test_get_polygon_from_manifest(test_data_folder):

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -7,9 +7,8 @@ from hyp3lib.dem import get_best_dem, utm_from_lat_lon, get_coverage_geometry
 
 
 def test_get_best_dem():
-    # assert get_best_dem(y_min=38.2, y_max=38.8, x_min=-110.8, x_max=-110.2) == 'NED13'
+    assert get_best_dem(y_min=37.0, y_max=38.0, x_min=-118.0, x_max=-117.0) == 'COP30'
     assert get_best_dem(y_min=-6.8, y_max=-6.2, x_min=27.2, x_max=27.8) == 'SRTMGL1'
-    # assert get_best_dem(y_min=67.9, y_max=68.1, x_min=-155.6, x_max=-155.4) == 'NED2'
     assert get_best_dem(y_min=59.975, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
     assert get_best_dem(y_min=59.976, y_max=60.1, x_min=99.5, x_max=100.5) == 'COP30'
 


### PR DESCRIPTION
This PR is supported by new files in the `asf-dem-west` bucket in S3:

```
$ aws s3 ls s3://asf-dem-west/v2/
2021-01-08 18:00:13   13374730 cop30.vrt
2021-01-08 18:00:25     204200 cop30_coverage.geojson
2021-01-08 18:50:08   48537955 cop30_gdalinfo.json
2021-01-08 20:50:54    6320219 srtmgl1.vrt
2021-01-08 18:00:35     175002 srtmgl1_coverage.geojson
2021-01-08 20:17:30   23266848 srtmgl1_gdalinfo.json
```

`*_gdalinfo.json` - The results of a gdal.Info(..., format='json') call against the DEM
`*_coverage.geojson` - A geojson describing the DEM coverage generated by handing the `gdalinfo.json` to `hyp3lib.dem.build_geojson()`
`*.vrt` - A global virtual raster (vrt) generated by handing the `gdalinfo.json` to `hyp3lib.dem.build_vrt()`


# TODOs
- still need to add code to support the antimeridian
- still need to add code to address pixel as point vs pixel as area