### PR TITLE
pin numpy<1.24 due to compatability errors

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - lxml
   - matplotlib
   - netCDF4
-  - numpy
+  - numpy<1.24
   - pillow
   - pyproj>=2
   - pyshp

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'lxml',
         'matplotlib',
         'netCDF4',
-        'numpy',
+        'numpy<1.24',
         'pillow',
         'pyproj>=2',
         'pyshp',


### PR DESCRIPTION
`numpy.int`, used in get_dem.py and possibly elsewhere, was deprecated in v1.20 and removed in v1.24. This causes tests to fail when using `numpy>=1.24`, example below.

- https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

Note that hyp3-gamma separately pins `numpy>=1.21,<1.22`, so we maintain compatibility with that package.


```
______________________________ test_get_dem_ned13 ______________________________

tmp_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_get_dem_ned130')
test_data_folder = PosixPath('/home/runner/work/hyp3-lib/hyp3-lib/tests/data')

    def test_get_dem_ned13(tmp_path, test_data_folder):
        chdir(tmp_path)
        output_file = tmp_path / 'dem.tif'
>       name = get_dem(y_min=37.99, y_max=37.999, x_min=-123.02, x_max=-123.01, outfile=str(output_file), post=30.0)

/home/runner/work/hyp3-lib/hyp3-lib/tests/test_get_dem.py:117: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/share/miniconda/envs/hyp3-lib/lib/python3.9/site-packages/hyp3lib/get_dem.py:275: in get_dem
    write_vrt(demproj, nodata, tile_list, poly_list, 'temp.vrt')
/usr/share/miniconda/envs/hyp3-lib/lib/python3.9/site-packages/hyp3lib/get_dem.py:167: in write_vrt
    raster_x_size = np.int(np.rint((max_lon - min_lon) / pix_size)) + 1
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

attr = 'int'

    def __getattr__(attr):
        # Warn for expired attributes, and return a dummy function
        # that always raises an exception.
        import warnings
        import math
        try:
            msg = __expired_functions__[attr]
        except KeyError:
            pass
        else:
            warnings.warn(msg, DeprecationWarning, stacklevel=2)
    
            def _expired(*args, **kwds):
                raise RuntimeError(msg)
    
            return _expired
    
        # Emit warnings for deprecated attributes
        try:
            val, msg = __deprecated_attrs__[attr]
        except KeyError:
            pass
        else:
            warnings.warn(msg, DeprecationWarning, stacklevel=2)
            return val
    
        if attr in __future_scalars__:
            # And future warnings for those that will change, but also give
            # the AttributeError
            warnings.warn(
                f"In the future `np.{attr}` will be defined as the "
                "corresponding NumPy scalar.", FutureWarning, stacklevel=2)
    
        if attr in __former_attrs__:
>           raise AttributeError(__former_attrs__[attr])
E           AttributeError: module 'numpy' has no attribute 'int'.
E           `np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E               https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

/usr/share/miniconda/envs/hyp3-lib/lib/python3.9/site-packages/numpy/__init__.py:324: AttributeError
```