### PR TITLE
Update formatting to pass Flake8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 * `hyp3lib` now uses a `src` layout per this [recommendation](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/).
 * `hyp3lib` now only uses `pyproject.toml` for package creation now that `setuptools` recommends [not using setup.py](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#setuppy-discouraged).
-* Updated GitHub Actions to current HyP3 standards
+* Updated GitHub Actions to current HyP3 standards.
+* Updated formatting using Ruff to pass flake8 check.
 
 ### Remove
 * All hyp3lib functionality not currently being used by one of these GitHub orgs: ASFHyP3, asfadmin, ASFOpenSARLab, access-cloud-based-insar, dbekaert, ASFBinderRecipes, or insarlab. For a full list of the deleted files, see [here](https://github.com/ASFHyP3/hyp3-lib/pull/286).
-* Removed now unused dependencies from `pyproject.toml` and `environment.yml`
+* Removed now unused dependencies from `pyproject.toml` and `environment.yml`.
 
 ## [2.0.2]
 

--- a/src/hyp3lib/SLC_copy_S1_fullSW.py
+++ b/src/hyp3lib/SLC_copy_S1_fullSW.py
@@ -55,7 +55,8 @@ def SLC_copy_S1_fullSW(path, slcname, tabin, burst_tab, mode=2, dem=None, dempat
         mliwidth = getParameter('../{}.mli.par'.format(slcname), 'range_samples')
         mlinline = getParameter('../{}.mli.par'.format(slcname), 'azimuth_lines')
 
-        cmd = 'GC_map_mod ../{SLC}.mli.par  - {DP}/{DEM}.par {DP}/{DEM}.dem 2 2 demseg.par demseg ../{SLC}.mli  MAP2RDC inc pix ls_map 1 1'.format(
+        # FIXME: Convert to an f-string
+        cmd = 'GC_map_mod ../{SLC}.mli.par  - {DP}/{DEM}.par {DP}/{DEM}.dem 2 2 demseg.par demseg ../{SLC}.mli  MAP2RDC inc pix ls_map 1 1'.format(  # noqa: E501
             SLC=slcname, DEM=dem, DP=dempath
         )
         execute(cmd, uselogging=True)
@@ -65,7 +66,8 @@ def SLC_copy_S1_fullSW(path, slcname, tabin, burst_tab, mode=2, dem=None, dempat
         cmd = 'geocode MAP2RDC demseg {} HGT_SAR_{}_{} {} {}'.format(demwidth, raml, azml, mliwidth, mlinline)
         execute(cmd, uselogging=True)
 
-        cmd = 'gc_map ../{SLC}.mli.par - {DP}/{DEM}.par 1 demseg.par demseg map_to_rdc 2 2 pwr_sim_map - - inc_flat'.format(
+        # FIXME: Convert to an f-string
+        cmd = 'gc_map ../{SLC}.mli.par - {DP}/{DEM}.par 1 demseg.par demseg map_to_rdc 2 2 pwr_sim_map - - inc_flat'.format(  # noqa: E501
             SLC=slcname, DP=dempath, DEM=dem
         )
         execute(cmd, uselogging=True)

--- a/src/hyp3lib/SLC_copy_S1_fullSW.py
+++ b/src/hyp3lib/SLC_copy_S1_fullSW.py
@@ -1,10 +1,11 @@
 """re-process S1 SLC imagery into gamma format SLCs"""
-import logging
 import argparse
-from hyp3lib.execute import execute
-from hyp3lib.getParameter import getParameter
+import logging
 import os
 import shutil
+
+from hyp3lib.execute import execute
+from hyp3lib.getParameter import getParameter
 
 
 def SLC_copy_S1_fullSW(path, slcname, tabin, burst_tab, mode=2, dem=None, dempath=None, raml=10, azml=2):

--- a/src/hyp3lib/SLC_copy_S1_fullSW.py
+++ b/src/hyp3lib/SLC_copy_S1_fullSW.py
@@ -7,70 +7,71 @@ import os
 import shutil
 
 
-def SLC_copy_S1_fullSW(path,slcname,tabin,burst_tab,mode=2,dem=None,dempath=None,raml=10,azml=2):
-
-    logging.info("Using range looks {}".format(raml))
-    logging.info("Using azimuth looks {}".format(azml))
-    logging.info("Operating in mode {}".format(mode))
-    logging.info("In directory {}".format(os.getcwd()))
+def SLC_copy_S1_fullSW(path, slcname, tabin, burst_tab, mode=2, dem=None, dempath=None, raml=10, azml=2):
+    logging.info('Using range looks {}'.format(raml))
+    logging.info('Using azimuth looks {}'.format(azml))
+    logging.info('Operating in mode {}'.format(mode))
+    logging.info('In directory {}'.format(os.getcwd()))
 
     if not os.path.isfile(tabin):
-        logging.error("ERROR: Can't find tab file {} in {}".format(tabin,os.getcwd()))
-    f = open(tabin,"r")
-    g = open("TAB_swFULL","w")
+        logging.error("ERROR: Can't find tab file {} in {}".format(tabin, os.getcwd()))
+    f = open(tabin, 'r')
+    g = open('TAB_swFULL', 'w')
     for line in f:
         s = line.split()
         for i in range(len(s)):
-            g.write("{} ".format(os.path.join(path,s[i])))
-        g.write("\n")
+            g.write('{} '.format(os.path.join(path, s[i])))
+        g.write('\n')
     f.close()
     g.close()
 
     wrk = os.getcwd()
 
-    cmd = "SLC_copy_S1_TOPS {} {} {}".format(tabin,"TAB_swFULL",burst_tab)
-    execute(cmd,uselogging=True)
+    cmd = 'SLC_copy_S1_TOPS {} {} {}'.format(tabin, 'TAB_swFULL', burst_tab)
+    execute(cmd, uselogging=True)
 
-    shutil.copy(tabin,path)
+    shutil.copy(tabin, path)
     os.chdir(path)
 
-    cmd = "SLC_mosaic_S1_TOPS {TAB} {SLC}.slc {SLC}.slc.par {RL} {AL}".format(TAB = tabin,
-      SLC=slcname,RL=raml,AL=azml)
-    execute(cmd,uselogging=True)
+    cmd = 'SLC_mosaic_S1_TOPS {TAB} {SLC}.slc {SLC}.slc.par {RL} {AL}'.format(TAB=tabin, SLC=slcname, RL=raml, AL=azml)
+    execute(cmd, uselogging=True)
 
-    width = getParameter("{}.slc.par".format(slcname),"range_samples")
-    cmd = "rasSLC {}.slc {} 1 0 50 10".format(slcname,width)
-    execute(cmd,uselogging=True)
+    width = getParameter('{}.slc.par'.format(slcname), 'range_samples')
+    cmd = 'rasSLC {}.slc {} 1 0 50 10'.format(slcname, width)
+    execute(cmd, uselogging=True)
 
-    cmd = "multi_S1_TOPS {TAB} {SLC}.mli {SLC}.mli.par {RL} {AL}".format(TAB=tabin,SLC=slcname,RL=raml,AL=azml)
-    execute(cmd,uselogging=True)
+    cmd = 'multi_S1_TOPS {TAB} {SLC}.mli {SLC}.mli.par {RL} {AL}'.format(TAB=tabin, SLC=slcname, RL=raml, AL=azml)
+    execute(cmd, uselogging=True)
 
     mode = int(mode)
     if mode == 1:
+        logging.info('currently in {}'.format(os.getcwd()))
+        logging.info('creating directory DEM')
 
-        logging.info("currently in {}".format(os.getcwd()))
-        logging.info("creating directory DEM")
+        if not os.path.exists('DEM'):
+            os.mkdir('DEM')
+        os.chdir('DEM')
+        mliwidth = getParameter('../{}.mli.par'.format(slcname), 'range_samples')
+        mlinline = getParameter('../{}.mli.par'.format(slcname), 'azimuth_lines')
 
-        if not os.path.exists("DEM"):
-            os.mkdir("DEM")
-        os.chdir("DEM")
-        mliwidth = getParameter("../{}.mli.par".format(slcname),"range_samples")
-        mlinline = getParameter("../{}.mli.par".format(slcname),"azimuth_lines")
+        cmd = 'GC_map_mod ../{SLC}.mli.par  - {DP}/{DEM}.par {DP}/{DEM}.dem 2 2 demseg.par demseg ../{SLC}.mli  MAP2RDC inc pix ls_map 1 1'.format(
+            SLC=slcname, DEM=dem, DP=dempath
+        )
+        execute(cmd, uselogging=True)
 
-        cmd = "GC_map_mod ../{SLC}.mli.par  - {DP}/{DEM}.par {DP}/{DEM}.dem 2 2 demseg.par demseg ../{SLC}.mli  MAP2RDC inc pix ls_map 1 1".format(SLC=slcname,DEM=dem,DP=dempath)
-        execute(cmd,uselogging=True)
+        demwidth = getParameter('demseg.par', 'width')
 
-        demwidth = getParameter("demseg.par","width")
+        cmd = 'geocode MAP2RDC demseg {} HGT_SAR_{}_{} {} {}'.format(demwidth, raml, azml, mliwidth, mlinline)
+        execute(cmd, uselogging=True)
 
-        cmd = "geocode MAP2RDC demseg {} HGT_SAR_{}_{} {} {}".format(demwidth,raml,azml,mliwidth,mlinline)
-        execute(cmd,uselogging=True)
+        cmd = 'gc_map ../{SLC}.mli.par - {DP}/{DEM}.par 1 demseg.par demseg map_to_rdc 2 2 pwr_sim_map - - inc_flat'.format(
+            SLC=slcname, DP=dempath, DEM=dem
+        )
+        execute(cmd, uselogging=True)
 
-        cmd = "gc_map ../{SLC}.mli.par - {DP}/{DEM}.par 1 demseg.par demseg map_to_rdc 2 2 pwr_sim_map - - inc_flat".format(SLC=slcname,DP=dempath,DEM=dem)
-        execute(cmd,uselogging=True)
+        os.chdir('..')
 
-        os.chdir("..")
-
-    shutil.copy(tabin,"SLC{}_tab".format(mode))
+    shutil.copy(tabin, 'SLC{}_tab'.format(mode))
     os.chdir(wrk)
 
 
@@ -81,15 +82,15 @@ def main():
         prog=os.path.basename(__file__),
         description=__doc__,
     )
-    parser.add_argument('outDir',help="Absolute path to destination folder")
-    parser.add_argument('slcID',help="SLC identifier (e.g. 20150429)")
-    parser.add_argument('slcTab',help='SLC Tab file')
-    parser.add_argument('burstTab',help='Burst tab for which bursts to copy')
-    parser.add_argument('mode',help='1 = master image, 2 = slave image')
-    parser.add_argument('-d','--dem',help='Name of DEM file',dest="dem")
-    parser.add_argument('-p','--path',help='Path to DEM file',dest="path")
-    parser.add_argument('-rl','--rangelooks',default='10',help='Number of range looks',dest="rl")
-    parser.add_argument('-al','--azimuthlooks',default='2',help='Number of range looks',dest="al")
+    parser.add_argument('outDir', help='Absolute path to destination folder')
+    parser.add_argument('slcID', help='SLC identifier (e.g. 20150429)')
+    parser.add_argument('slcTab', help='SLC Tab file')
+    parser.add_argument('burstTab', help='Burst tab for which bursts to copy')
+    parser.add_argument('mode', help='1 = master image, 2 = slave image')
+    parser.add_argument('-d', '--dem', help='Name of DEM file', dest='dem')
+    parser.add_argument('-p', '--path', help='Path to DEM file', dest='path')
+    parser.add_argument('-rl', '--rangelooks', default='10', help='Number of range looks', dest='rl')
+    parser.add_argument('-al', '--azimuthlooks', default='2', help='Number of range looks', dest='al')
     args = parser.parse_args()
 
     if not os.path.exists(args.slcTab):
@@ -98,15 +99,18 @@ def main():
     if not os.path.exists(args.burstTab):
         logging.error("ERROR:  Can't find burst tab file {}".format(args.burstTab))
 
-    logFile = "SLC_copy_S1_fullSW_log.txt"
-    logging.basicConfig(filename=logFile,format='%(asctime)s - %(levelname)s - %(message)s',
-                        datefmt='%m/%d/%Y %I:%M:%S %p',level=logging.DEBUG)
+    logFile = 'SLC_copy_S1_fullSW_log.txt'
+    logging.basicConfig(
+        filename=logFile,
+        format='%(asctime)s - %(levelname)s - %(message)s',
+        datefmt='%m/%d/%Y %I:%M:%S %p',
+        level=logging.DEBUG,
+    )
     logging.getLogger().addHandler(logging.StreamHandler())
-    logging.info("Starting run")
+    logging.info('Starting run')
 
     SLC_copy_S1_fullSW(
-        args.outDir, args.slcID, args.slcTab, args.burstTab, args.mode, args.dem,
-        args.path, args.rl, args.al
+        args.outDir, args.slcID, args.slcTab, args.burstTab, args.mode, args.dem, args.path, args.rl, args.al
     )
 
 

--- a/src/hyp3lib/__init__.py
+++ b/src/hyp3lib/__init__.py
@@ -11,6 +11,7 @@ from hyp3lib.exceptions import (
     OrbitDownloadError,
 )
 
+
 try:
     __version__ = version(__name__)
 except PackageNotFoundError:

--- a/src/hyp3lib/__init__.py
+++ b/src/hyp3lib/__init__.py
@@ -14,11 +14,13 @@ from hyp3lib.exceptions import (
 try:
     __version__ = version(__name__)
 except PackageNotFoundError:
-    print(f'{__name__} package is not installed!\n'
-          f'Install in editable/develop mode via (from the top of this repo):\n'
-          f'   python -m pip install -e .[develop]\n'
-          f'Or, to just get the version number use:\n'
-          f'   python setup.py --version')
+    print(
+        f'{__name__} package is not installed!\n'
+        f'Install in editable/develop mode via (from the top of this repo):\n'
+        f'   python -m pip install -e .[develop]\n'
+        f'Or, to just get the version number use:\n'
+        f'   python setup.py --version'
+    )
 
 __all__ = [
     '__version__',

--- a/src/hyp3lib/asf_geometry.py
+++ b/src/hyp3lib/asf_geometry.py
@@ -12,486 +12,471 @@ from hyp3lib.saa_func_lib import get_zone
 
 # Determine the boundary polygon of a GeoTIFF file
 def geotiff2polygon_ext(geotiff):
+    raster = gdal.Open(geotiff)
+    proj = osr.SpatialReference()
+    proj.ImportFromWkt(raster.GetProjectionRef())
+    gt = raster.GetGeoTransform()
+    originX = gt[0]
+    originY = gt[3]
+    pixelWidth = gt[1]
+    pixelHeight = gt[5]
+    cols = raster.RasterXSize
+    rows = raster.RasterYSize
+    polygon = ogr.Geometry(ogr.wkbPolygon)
+    ring = ogr.Geometry(ogr.wkbLinearRing)
+    ring.AddPoint_2D(originX, originY)
+    ring.AddPoint_2D(originX + cols * pixelWidth, originY)
+    ring.AddPoint_2D(originX + cols * pixelWidth, originY + rows * pixelHeight)
+    ring.AddPoint_2D(originX, originY + rows * pixelHeight)
+    ring.AddPoint_2D(originX, originY)
+    polygon.AddGeometry(ring)
+    ring = None
+    raster = None
 
-  raster = gdal.Open(geotiff)
-  proj = osr.SpatialReference()
-  proj.ImportFromWkt(raster.GetProjectionRef())
-  gt = raster.GetGeoTransform()
-  originX = gt[0]
-  originY = gt[3]
-  pixelWidth = gt[1]
-  pixelHeight = gt[5]
-  cols = raster.RasterXSize
-  rows = raster.RasterYSize
-  polygon = ogr.Geometry(ogr.wkbPolygon)
-  ring = ogr.Geometry(ogr.wkbLinearRing)
-  ring.AddPoint_2D(originX, originY)
-  ring.AddPoint_2D(originX + cols*pixelWidth, originY)
-  ring.AddPoint_2D(originX + cols*pixelWidth, originY + rows*pixelHeight)
-  ring.AddPoint_2D(originX, originY + rows*pixelHeight)
-  ring.AddPoint_2D(originX, originY)
-  polygon.AddGeometry(ring)
-  ring = None
-  raster = None
-
-  return (polygon, proj)
+    return (polygon, proj)
 
 
 def geotiff2polygon(geotiff):
-
-  (polygon, proj) = geotiff2polygon_ext(geotiff)
-  return polygon
+    (polygon, proj) = geotiff2polygon_ext(geotiff)
+    return polygon
 
 
 def geotiff2boundary_mask(inGeotiff, tsEPSG, threshold, use_closing=True):
-
-  inRaster = gdal.Open(inGeotiff)
-  proj = osr.SpatialReference()
-  proj.ImportFromWkt(inRaster.GetProjectionRef())
-  if proj.GetAttrValue('AUTHORITY', 0) == 'EPSG':
-    epsg = int(proj.GetAttrValue('AUTHORITY', 1))
-
-  if tsEPSG != 0 and epsg != tsEPSG:
-    print('Reprojecting ...')
-    inRaster = reproject2grid(inRaster, tsEPSG)
+    inRaster = gdal.Open(inGeotiff)
+    proj = osr.SpatialReference()
     proj.ImportFromWkt(inRaster.GetProjectionRef())
     if proj.GetAttrValue('AUTHORITY', 0) == 'EPSG':
-      epsg = int(proj.GetAttrValue('AUTHORITY', 1))
+        epsg = int(proj.GetAttrValue('AUTHORITY', 1))
 
-  geoTrans = inRaster.GetGeoTransform()
-  inBand = inRaster.GetRasterBand(1)
-  noDataValue = inBand.GetNoDataValue()
-  data = inBand.ReadAsArray()
-  minValue = np.min(data)
+    if tsEPSG != 0 and epsg != tsEPSG:
+        print('Reprojecting ...')
+        inRaster = reproject2grid(inRaster, tsEPSG)
+        proj.ImportFromWkt(inRaster.GetProjectionRef())
+        if proj.GetAttrValue('AUTHORITY', 0) == 'EPSG':
+            epsg = int(proj.GetAttrValue('AUTHORITY', 1))
 
-  ### Check for black fill
-  if minValue > 0:
-    data /= data
-    colFirst = 0
-    rowFirst = 0
-  else:
-    data[np.isnan(data)==True] = noDataValue
-    if threshold is not None:
-      print('Applying threshold ({0}) ...'.format(threshold))
-      data[data<np.float(threshold)] = noDataValue
-    if np.isnan(noDataValue):
-      data[np.isnan(data)==False] = 1
+    geoTrans = inRaster.GetGeoTransform()
+    inBand = inRaster.GetRasterBand(1)
+    noDataValue = inBand.GetNoDataValue()
+    data = inBand.ReadAsArray()
+    minValue = np.min(data)
+
+    ### Check for black fill
+    if minValue > 0:
+        data /= data
+        colFirst = 0
+        rowFirst = 0
     else:
-      data[data>noDataValue] = 1
-    if use_closing:
-      data = ndimage.binary_closing(data, iterations=10,
-        structure=np.ones((3,3))).astype(data.dtype)
+        data[np.isnan(data) == True] = noDataValue
+        if threshold is not None:
+            print('Applying threshold ({0}) ...'.format(threshold))
+            data[data < np.float(threshold)] = noDataValue
+        if np.isnan(noDataValue):
+            data[np.isnan(data) == False] = 1
+        else:
+            data[data > noDataValue] = 1
+        if use_closing:
+            data = ndimage.binary_closing(data, iterations=10, structure=np.ones((3, 3))).astype(data.dtype)
+        inRaster = None
+
+        (data, colFirst, rowFirst, geoTrans) = cut_blackfill(data, geoTrans)
+
+    return (data, colFirst, rowFirst, geoTrans, proj)
+
+
+def reproject2grid(inRaster, tsEPSG, xRes=None):
+    # Read basic metadata
+    geoTrans = inRaster.GetGeoTransform()
+    proj = osr.SpatialReference()
+    proj.ImportFromEPSG(tsEPSG)
+
+    # Define warping options
+    rasterFormat = 'VRT'
+    if xRes is None:
+        xRes = geoTrans[1]
+    yRes = xRes
+    resampleAlg = gdal.GRA_Bilinear
+    options = ['COMPRESS=DEFLATE']
+
+    outRaster = gdal.Warp(
+        '',
+        inRaster,
+        format=rasterFormat,
+        dstSRS=proj,
+        targetAlignedPixels=True,
+        xRes=xRes,
+        yRes=yRes,
+        resampleAlg=resampleAlg,
+        options=options,
+    )
     inRaster = None
 
-    (data, colFirst, rowFirst, geoTrans) = cut_blackfill(data, geoTrans)
-
-  return (data, colFirst, rowFirst, geoTrans, proj)
-
-
-def reproject2grid(inRaster, tsEPSG, xRes = None ):
-
-  # Read basic metadata
-  geoTrans = inRaster.GetGeoTransform()
-  proj = osr.SpatialReference()
-  proj.ImportFromEPSG(tsEPSG)
-
-  # Define warping options
-  rasterFormat = 'VRT'
-  if xRes is None:
-      xRes = geoTrans[1]
-  yRes = xRes
-  resampleAlg = gdal.GRA_Bilinear
-  options = ['COMPRESS=DEFLATE']
-
-  outRaster = gdal.Warp('', inRaster, format=rasterFormat, dstSRS=proj,
-    targetAlignedPixels=True, xRes=xRes, yRes=yRes, resampleAlg=resampleAlg,
-    options=options)
-  inRaster = None
-
-  return outRaster
+    return outRaster
 
 
 def cut_blackfill(data, geoTrans):
+    originX = geoTrans[0]
+    originY = geoTrans[3]
+    pixelSize = geoTrans[1]
+    colProfile = list(data.max(axis=1))
+    rows = colProfile.count(1)
+    rowFirst = colProfile.index(1)
+    rowProfile = list(data.max(axis=0))
+    cols = rowProfile.count(1)
+    colFirst = rowProfile.index(1)
+    originX += colFirst * pixelSize
+    originY -= rowFirst * pixelSize
+    data = data[rowFirst : rows + rowFirst, colFirst : cols + colFirst]
+    geoTrans = (originX, pixelSize, 0, originY, 0, -pixelSize)
 
-  originX = geoTrans[0]
-  originY = geoTrans[3]
-  pixelSize = geoTrans[1]
-  colProfile = list(data.max(axis=1))
-  rows = colProfile.count(1)
-  rowFirst = colProfile.index(1)
-  rowProfile = list(data.max(axis=0))
-  cols = rowProfile.count(1)
-  colFirst = rowProfile.index(1)
-  originX += colFirst*pixelSize
-  originY -= rowFirst*pixelSize
-  data = data[rowFirst:rows+rowFirst,colFirst:cols+colFirst]
-  geoTrans = (originX, pixelSize, 0, originY, 0, -pixelSize)
-
-  return (data, colFirst, rowFirst, geoTrans)
+    return (data, colFirst, rowFirst, geoTrans)
 
 
 def geotiff_overlap(firstFile, secondFile, method):
+    # Check map projections
+    raster = gdal.Open(firstFile)
+    proj = raster.GetProjection()
+    gt = raster.GetGeoTransform()
+    pixelSize = gt[1]
+    raster = None
 
-  # Check map projections
-  raster = gdal.Open(firstFile)
-  proj = raster.GetProjection()
-  gt = raster.GetGeoTransform()
-  pixelSize = gt[1]
-  raster = None
+    # Extract boundary polygons
+    firstPolygon = geotiff2polygon(firstFile)
+    secondPolygon = geotiff2polygon(secondFile)
 
-  # Extract boundary polygons
-  firstPolygon = geotiff2polygon(firstFile)
-  secondPolygon = geotiff2polygon(secondFile)
+    if method == 'intersection':
+        overlap = firstPolygon.Intersection(secondPolygon)
+    elif method == 'union':
+        overlap = firstPolygon.Union(secondPolygon)
 
-  if method == 'intersection':
-    overlap = firstPolygon.Intersection(secondPolygon)
-  elif method == 'union':
-    overlap = firstPolygon.Union(secondPolygon)
-
-  return (firstPolygon, secondPolygon, overlap, proj, pixelSize)
+    return (firstPolygon, secondPolygon, overlap, proj, pixelSize)
 
 
 def overlap_indices(polygon, boundary, pixelSize):
+    polyEnv = polygon.GetEnvelope()
+    boundEnv = boundary.GetEnvelope()
+    xOff = int((boundEnv[0] - polyEnv[0]) / pixelSize)
+    yOff = int((polyEnv[3] - boundEnv[3]) / pixelSize)
+    xCount = int((boundEnv[1] - boundEnv[0]) / pixelSize)
+    yCount = int((boundEnv[3] - boundEnv[2]) / pixelSize)
 
-  polyEnv = polygon.GetEnvelope()
-  boundEnv = boundary.GetEnvelope()
-  xOff = int((boundEnv[0] - polyEnv[0]) / pixelSize)
-  yOff = int((polyEnv[3] - boundEnv[3]) / pixelSize)
-  xCount = int((boundEnv[1] - boundEnv[0]) / pixelSize)
-  yCount = int((boundEnv[3] - boundEnv[2]) / pixelSize)
-
-  return (xOff, yOff, xCount, yCount)
+    return (xOff, yOff, xCount, yCount)
 
 
 # Extract geometry from shapefile
 def shape2geometry(shapeFile, field):
+    name = []
+    fields = []
+    driver = ogr.GetDriverByName('ESRI Shapefile')
+    shape = driver.Open(shapeFile, 0)
+    multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
+    layer = shape.GetLayer()
+    spatialRef = layer.GetSpatialRef()
+    layerDef = layer.GetLayerDefn()
+    for i in range(layerDef.GetFieldCount()):
+        fields.append(layerDef.GetFieldDefn(i).GetName())
+    if field not in fields:
+        return (None, None, None)
+    for feature in layer:
+        geometry = feature.GetGeometryRef()
+        count = geometry.GetGeometryCount()
+        if geometry.GetGeometryName() == 'MULTIPOLYGON':
+            for i in range(0, count):
+                polygon = geometry.GetGeometryRef(i)
+                multipolygon.AddGeometry(polygon)
+                name.append(feature.GetField(field))
+        else:
+            multipolygon.AddGeometry(geometry)
+            name.append(feature.GetField(field))
+    shape.Destroy()
 
-  name = []
-  fields = []
-  driver = ogr.GetDriverByName('ESRI Shapefile')
-  shape = driver.Open(shapeFile, 0)
-  multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
-  layer = shape.GetLayer()
-  spatialRef = layer.GetSpatialRef()
-  layerDef = layer.GetLayerDefn()
-  for i in range(layerDef.GetFieldCount()):
-    fields.append(layerDef.GetFieldDefn(i).GetName())
-  if field not in fields:
-    return (None, None, None)
-  for feature in layer:
-    geometry = feature.GetGeometryRef()
-    count = geometry.GetGeometryCount()
-    if geometry.GetGeometryName() == 'MULTIPOLYGON':
-      for i in range(0, count):
-        polygon = geometry.GetGeometryRef(i)
-        multipolygon.AddGeometry(polygon)
-        name.append(feature.GetField(field))
-    else:
-      multipolygon.AddGeometry(geometry)
-      name.append(feature.GetField(field))
-  shape.Destroy()
-
-  return (multipolygon, spatialRef, name)
+    return (multipolygon, spatialRef, name)
 
 
 def shape2geometry_ext(shapeFile):
+    values = []
+    fields = []
+    driver = ogr.GetDriverByName('ESRI Shapefile')
+    shape = driver.Open(shapeFile, 0)
+    layer = shape.GetLayer()
+    spatialRef = layer.GetSpatialRef()
+    layerDef = layer.GetLayerDefn()
+    featureCount = layerDef.GetFieldCount()
+    for ii in range(featureCount):
+        field = {}
+        field['name'] = layerDef.GetFieldDefn(ii).GetName()
+        field['type'] = layerDef.GetFieldDefn(ii).GetType()
+        if field['type'] == ogr.OFTString:
+            field['width'] = layerDef.GetFieldDefn(ii).GetWidth()
+        fields.append(field)
+    for feature in layer:
+        multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
+        geometry = feature.GetGeometryRef()
+        count = geometry.GetGeometryCount()
+        if geometry.GetGeometryName() == 'MULTIPOLYGON':
+            for i in range(0, count):
+                polygon = geometry.GetGeometryRef(i)
+                multipolygon.AddGeometry(polygon)
+        else:
+            multipolygon.AddGeometry(geometry)
+        value = {}
+        for field in fields:
+            value[field['name']] = feature.GetField(field['name'])
+        value['geometry'] = multipolygon
+        values.append(value)
+    shape.Destroy()
 
-  values = []
-  fields = []
-  driver = ogr.GetDriverByName('ESRI Shapefile')
-  shape = driver.Open(shapeFile, 0)
-  layer = shape.GetLayer()
-  spatialRef = layer.GetSpatialRef()
-  layerDef = layer.GetLayerDefn()
-  featureCount = layerDef.GetFieldCount()
-  for ii in range(featureCount):
-    field = {}
-    field['name'] = layerDef.GetFieldDefn(ii).GetName()
-    field['type'] = layerDef.GetFieldDefn(ii).GetType()
-    if field['type'] == ogr.OFTString:
-      field['width'] = layerDef.GetFieldDefn(ii).GetWidth()
-    fields.append(field)
-  for feature in layer:
-    multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
-    geometry = feature.GetGeometryRef()
-    count = geometry.GetGeometryCount()
-    if geometry.GetGeometryName() == 'MULTIPOLYGON':
-      for i in range(0, count):
-        polygon = geometry.GetGeometryRef(i)
-        multipolygon.AddGeometry(polygon)
-    else:
-      multipolygon.AddGeometry(geometry)
-    value = {}
-    for field in fields:
-      value[field['name']] = feature.GetField(field['name'])
-    value['geometry'] = multipolygon
-    values.append(value)
-  shape.Destroy()
-
-  return (fields, values, spatialRef)
+    return (fields, values, spatialRef)
 
 
 # Save geometry with fields to shapefile
 def geometry2shape(fields, values, spatialRef, merge, shapeFile):
-
-  driver = ogr.GetDriverByName('ESRI Shapefile')
-  if os.path.exists(shapeFile):
-    driver.DeleteDataSource(shapeFile)
-  outShape = driver.CreateDataSource(shapeFile)
-  outLayer = outShape.CreateLayer('layer', srs=spatialRef)
-  for field in fields:
-    fieldDefinition = ogr.FieldDefn(field['name'], field['type'])
-    if field['type'] == ogr.OFTString:
-      fieldDefinition.SetWidth(field['width'])
-    elif field['type'] == ogr.OFTReal:
-      fieldDefinition.SetWidth(24)
-      fieldDefinition.SetPrecision(8)
-    outLayer.CreateField(fieldDefinition)
-  featureDefinition = outLayer.GetLayerDefn()
-  if merge == True:
-    combine = ogr.Geometry(ogr.wkbMultiPolygon)
-    for value in values:
-      combine = combine.Union(value['geometry'])
-    outFeature = ogr.Feature(featureDefinition)
+    driver = ogr.GetDriverByName('ESRI Shapefile')
+    if os.path.exists(shapeFile):
+        driver.DeleteDataSource(shapeFile)
+    outShape = driver.CreateDataSource(shapeFile)
+    outLayer = outShape.CreateLayer('layer', srs=spatialRef)
     for field in fields:
-      name = field['name']
-      outFeature.SetField(name, 'multipolygon')
-    outFeature.SetGeometry(combine)
-    outLayer.CreateFeature(outFeature)
-    outFeature.Destroy()
-  else:
-    for value in values:
-      outFeature = ogr.Feature(featureDefinition)
-      for field in fields:
-        name = field['name']
-        outFeature.SetField(name, value[name])
-      outFeature.SetGeometry(value['geometry'])
-      outLayer.CreateFeature(outFeature)
-      outFeature.Destroy()
-  outShape.Destroy()
+        fieldDefinition = ogr.FieldDefn(field['name'], field['type'])
+        if field['type'] == ogr.OFTString:
+            fieldDefinition.SetWidth(field['width'])
+        elif field['type'] == ogr.OFTReal:
+            fieldDefinition.SetWidth(24)
+            fieldDefinition.SetPrecision(8)
+        outLayer.CreateField(fieldDefinition)
+    featureDefinition = outLayer.GetLayerDefn()
+    if merge == True:
+        combine = ogr.Geometry(ogr.wkbMultiPolygon)
+        for value in values:
+            combine = combine.Union(value['geometry'])
+        outFeature = ogr.Feature(featureDefinition)
+        for field in fields:
+            name = field['name']
+            outFeature.SetField(name, 'multipolygon')
+        outFeature.SetGeometry(combine)
+        outLayer.CreateFeature(outFeature)
+        outFeature.Destroy()
+    else:
+        for value in values:
+            outFeature = ogr.Feature(featureDefinition)
+            for field in fields:
+                name = field['name']
+                outFeature.SetField(name, value[name])
+            outFeature.SetGeometry(value['geometry'])
+            outLayer.CreateFeature(outFeature)
+            outFeature.Destroy()
+    outShape.Destroy()
 
 
 # Save data with fields to shapefile
-def data_geometry2shape_ext(data, fields, values, spatialRef, geoTrans,
-  classes, threshold, background, shapeFile):
+def data_geometry2shape_ext(data, fields, values, spatialRef, geoTrans, classes, threshold, background, shapeFile):
+    # Check input
+    if threshold is not None:
+        threshold = float(threshold)
+    if background is not None:
+        background = int(background)
 
-  # Check input
-  if threshold is not None:
-    threshold = float(threshold)
-  if background is not None:
-    background = int(background)
+    # Buffer data
+    (rows, cols) = data.shape
+    pixelSize = geoTrans[1]
+    originX = geoTrans[0] - 10 * pixelSize
+    originY = geoTrans[3] + 10 * pixelSize
+    geoTrans = (originX, pixelSize, 0, originY, 0, -pixelSize)
+    mask = np.zeros((rows + 20, cols + 20), dtype=np.float32)
+    mask[10 : rows + 10, 10 : cols + 10] = data
+    data = mask
 
-  # Buffer data
-  (rows, cols) = data.shape
-  pixelSize = geoTrans[1]
-  originX = geoTrans[0] - 10*pixelSize
-  originY = geoTrans[3] + 10*pixelSize
-  geoTrans = (originX, pixelSize, 0, originY, 0, -pixelSize)
-  mask = np.zeros((rows+20, cols+20), dtype=np.float32)
-  mask[10:rows+10,10:cols+10] = data
-  data = mask
+    # Save in memory
+    (rows, cols) = data.shape
+    data = data.astype(np.byte)
+    gdalDriver = gdal.GetDriverByName('Mem')
+    outRaster = gdalDriver.Create('value', cols, rows, 1, gdal.GDT_Byte)
+    outRaster.SetGeoTransform(geoTrans)
+    outRaster.SetProjection(spatialRef.ExportToWkt())
+    outBand = outRaster.GetRasterBand(1)
+    outBand.WriteArray(data)
 
-  # Save in memory
-  (rows, cols) = data.shape
-  data = data.astype(np.byte)
-  gdalDriver = gdal.GetDriverByName('Mem')
-  outRaster = gdalDriver.Create('value', cols, rows, 1, gdal.GDT_Byte)
-  outRaster.SetGeoTransform(geoTrans)
-  outRaster.SetProjection(spatialRef.ExportToWkt())
-  outBand = outRaster.GetRasterBand(1)
-  outBand.WriteArray(data)
-
-  # Write data to shapefile
-  driver = ogr.GetDriverByName('ESRI Shapefile')
-  if os.path.exists(shapeFile):
-    driver.DeleteDataSource(shapeFile)
-  outShape = driver.CreateDataSource(shapeFile)
-  outLayer = outShape.CreateLayer('polygon', srs=spatialRef)
-  outField = ogr.FieldDefn('value', ogr.OFTInteger)
-  outLayer.CreateField(outField)
-  gdal.Polygonize(outBand, None, outLayer, 0, [], callback=None)
-  for field in fields:
-    fieldDefinition = ogr.FieldDefn(field['name'], field['type'])
-    if field['type'] == ogr.OFTString:
-      fieldDefinition.SetWidth(field['width'])
+    # Write data to shapefile
+    driver = ogr.GetDriverByName('ESRI Shapefile')
+    if os.path.exists(shapeFile):
+        driver.DeleteDataSource(shapeFile)
+    outShape = driver.CreateDataSource(shapeFile)
+    outLayer = outShape.CreateLayer('polygon', srs=spatialRef)
+    outField = ogr.FieldDefn('value', ogr.OFTInteger)
+    outLayer.CreateField(outField)
+    gdal.Polygonize(outBand, None, outLayer, 0, [], callback=None)
+    for field in fields:
+        fieldDefinition = ogr.FieldDefn(field['name'], field['type'])
+        if field['type'] == ogr.OFTString:
+            fieldDefinition.SetWidth(field['width'])
+        outLayer.CreateField(fieldDefinition)
+    fieldDefinition = ogr.FieldDefn('area', ogr.OFTReal)
+    fieldDefinition.SetWidth(16)
+    fieldDefinition.SetPrecision(3)
     outLayer.CreateField(fieldDefinition)
-  fieldDefinition = ogr.FieldDefn('area', ogr.OFTReal)
-  fieldDefinition.SetWidth(16)
-  fieldDefinition.SetPrecision(3)
-  outLayer.CreateField(fieldDefinition)
-  fieldDefinition = ogr.FieldDefn('centroid', ogr.OFTString)
-  fieldDefinition.SetWidth(50)
-  outLayer.CreateField(fieldDefinition)
-  if classes:
-    fieldDefinition = ogr.FieldDefn('size', ogr.OFTString)
-    fieldDefinition.SetWidth(25)
+    fieldDefinition = ogr.FieldDefn('centroid', ogr.OFTString)
+    fieldDefinition.SetWidth(50)
     outLayer.CreateField(fieldDefinition)
-  _ = outLayer.GetLayerDefn()
-  for outFeature in outLayer:
-    for value in values:
-      for field in fields:
-        name = field['name']
-        outFeature.SetField(name, value[name])
-    cValue = outFeature.GetField('value')
-    fill = False
-    if cValue == 0:
-      fill = True
-    if background is not None and cValue == background:
-      fill = True
-    geometry = outFeature.GetGeometryRef()
-    area = float(geometry.GetArea())
-    outFeature.SetField('area', area)
     if classes:
-      for ii in range(len(classes)):
-        if area > classes[ii]['minimum'] and area < classes[ii]['maximum']:
-          outFeature.SetField('size',classes[ii]['class'])
-    centroid = geometry.Centroid().ExportToWkt()
-    outFeature.SetField('centroid', centroid)
-    if fill == False and area > threshold:
-      outLayer.SetFeature(outFeature)
-    else:
-      outLayer.DeleteFeature(outFeature.GetFID())
-  outShape.Destroy()
+        fieldDefinition = ogr.FieldDefn('size', ogr.OFTString)
+        fieldDefinition.SetWidth(25)
+        outLayer.CreateField(fieldDefinition)
+    _ = outLayer.GetLayerDefn()
+    for outFeature in outLayer:
+        for value in values:
+            for field in fields:
+                name = field['name']
+                outFeature.SetField(name, value[name])
+        cValue = outFeature.GetField('value')
+        fill = False
+        if cValue == 0:
+            fill = True
+        if background is not None and cValue == background:
+            fill = True
+        geometry = outFeature.GetGeometryRef()
+        area = float(geometry.GetArea())
+        outFeature.SetField('area', area)
+        if classes:
+            for ii in range(len(classes)):
+                if area > classes[ii]['minimum'] and area < classes[ii]['maximum']:
+                    outFeature.SetField('size', classes[ii]['class'])
+        centroid = geometry.Centroid().ExportToWkt()
+        outFeature.SetField('centroid', centroid)
+        if fill == False and area > threshold:
+            outLayer.SetFeature(outFeature)
+        else:
+            outLayer.DeleteFeature(outFeature.GetFID())
+    outShape.Destroy()
 
 
 def data_geometry2shape(data, fields, values, spatialRef, geoTrans, shapeFile):
-
-  return data_geometry2shape_ext(data, fields, values, spatialRef, geoTrans,
-    None, 0, None, shapeFile)
+    return data_geometry2shape_ext(data, fields, values, spatialRef, geoTrans, None, 0, None, shapeFile)
 
 
 def geotiff2data(inGeotiff):
+    inRaster = gdal.Open(inGeotiff)
+    proj = osr.SpatialReference()
+    proj.ImportFromWkt(inRaster.GetProjectionRef())
+    if proj.GetAttrValue('AUTHORITY', 0) == 'EPSG':
+        epsg = int(proj.GetAttrValue('AUTHORITY', 1))
+    geoTrans = inRaster.GetGeoTransform()
+    inBand = inRaster.GetRasterBand(1)
+    noData = inBand.GetNoDataValue()
+    data = inBand.ReadAsArray()
+    if data.dtype == np.uint8:
+        dtype = 'BYTE'
+    elif data.dtype == np.float32:
+        dtype = 'FLOAT'
+    elif data.dtype == np.float64:
+        dtype = 'DOUBLE'
 
-  inRaster = gdal.Open(inGeotiff)
-  proj = osr.SpatialReference()
-  proj.ImportFromWkt(inRaster.GetProjectionRef())
-  if proj.GetAttrValue('AUTHORITY', 0) == 'EPSG':
-    epsg = int(proj.GetAttrValue('AUTHORITY', 1))
-  geoTrans = inRaster.GetGeoTransform()
-  inBand = inRaster.GetRasterBand(1)
-  noData = inBand.GetNoDataValue()
-  data = inBand.ReadAsArray()
-  if data.dtype == np.uint8:
-    dtype = 'BYTE'
-  elif data.dtype == np.float32:
-    dtype = 'FLOAT'
-  elif data.dtype == np.float64:
-    dtype = 'DOUBLE'
-
-  return (data, geoTrans, proj, epsg, dtype, noData)
+    return (data, geoTrans, proj, epsg, dtype, noData)
 
 
 def data2geotiff(data, geoTrans, proj, dtype, noData, outFile):
-
-  (rows, cols) = data.shape
-  gdalDriver = gdal.GetDriverByName('GTiff')
-  if dtype == 'BYTE':
-    outRaster = gdalDriver.Create(outFile, cols, rows, 1, gdal.GDT_Byte,
-      ['COMPRESS=DEFLATE'])
-  elif dtype == 'FLOAT':
-    outRaster = gdalDriver.Create(outFile, cols, rows, 1, gdal.GDT_Float32,
-      ['COMPRESS=DEFLATE'])
-  outRaster.SetGeoTransform(geoTrans)
-  outRaster.SetProjection(proj.ExportToWkt())
-  outBand = outRaster.GetRasterBand(1)
-  outBand.SetNoDataValue(noData)
-  outBand.WriteArray(data)
-  outRaster = None
+    (rows, cols) = data.shape
+    gdalDriver = gdal.GetDriverByName('GTiff')
+    if dtype == 'BYTE':
+        outRaster = gdalDriver.Create(outFile, cols, rows, 1, gdal.GDT_Byte, ['COMPRESS=DEFLATE'])
+    elif dtype == 'FLOAT':
+        outRaster = gdalDriver.Create(outFile, cols, rows, 1, gdal.GDT_Float32, ['COMPRESS=DEFLATE'])
+    outRaster.SetGeoTransform(geoTrans)
+    outRaster.SetProjection(proj.ExportToWkt())
+    outBand = outRaster.GetRasterBand(1)
+    outBand.SetNoDataValue(noData)
+    outBand.WriteArray(data)
+    outRaster = None
 
 
 # Save raster information (fields, values) to CSV file
 def raster2csv(fields, values, csvFile):
-
-  header = []
-  for field in fields:
-    header.append(field['name'])
-  line = []
-  for value in values:
+    header = []
     for field in fields:
-      name = field['name']
-      line.append(value[name])
+        header.append(field['name'])
+    line = []
+    for value in values:
+        for field in fields:
+            name = field['name']
+            line.append(value[name])
 
-  with open(csvFile, 'wb') as outF:
-    writer = csv.writer(outF, delimiter=';')
-    writer.writerow(header)
-    writer.writerow(line)
+    with open(csvFile, 'wb') as outF:
+        writer = csv.writer(outF, delimiter=';')
+        writer.writerow(header)
+        writer.writerow(line)
 
 
 # Combine all geometries in a list
 def union_geometries(geometries):
+    combine = ogr.Geometry(ogr.wkbMultiPolygon)
+    for geometry in geometries:
+        combine = combine.Union(geometry)
 
-  combine = ogr.Geometry(ogr.wkbMultiPolygon)
-  for geometry in geometries:
-    combine = combine.Union(geometry)
-
-  return combine
+    return combine
 
 
 def spatial_query(source, reference, function):
+    # Extract information from tiles and boundary shapefiles
+    (geoTile, spatialRef, nameTile) = shape2geometry(reference, 'tile')
+    if geoTile is None:
+        raise GeometryError(f'Could not extract information (tile) out of shapefile {reference}')
+    (boundary, spatialRef, granule) = shape2geometry(source, 'granule')
+    if boundary is None:
+        raise GeometryError(f'Could not extract information (granule) out of shapefile {source}')
 
-  # Extract information from tiles and boundary shapefiles
-  (geoTile, spatialRef, nameTile) = shape2geometry(reference, 'tile')
-  if geoTile is None:
-    raise GeometryError(f'Could not extract information (tile) out of shapefile {reference}')
-  (boundary, spatialRef, granule) = shape2geometry(source, 'granule')
-  if boundary is None:
-    raise GeometryError(f'Could not extract information (granule) out of shapefile {source}')
+    # Perform the spatial analysis
+    i = 0
+    tile = []
+    multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
+    for geo in geoTile:
+        for bound in boundary:
+            if function == 'intersects':
+                intersection = bound.Intersection(geo)
+                if intersection.GetGeometryName() == 'POLYGON':
+                    if nameTile[i] not in tile:
+                        tile.append(nameTile[i])
+                        multipolygon.AddGeometry(geo)
+        i = i + 1
 
-  # Perform the spatial analysis
-  i = 0
-  tile = []
-  multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
-  for geo in geoTile:
-    for bound in boundary:
-      if function == 'intersects':
-        intersection = bound.Intersection(geo)
-        if intersection.GetGeometryName() == 'POLYGON':
-          if nameTile[i] not in tile:
-            tile.append(nameTile[i])
-            multipolygon.AddGeometry(geo)
-    i = i + 1
-
-  return (multipolygon, tile)
+    return (multipolygon, tile)
 
 
 # Converted geometry from projected to geographic
 def geometry_proj2geo(inMultipolygon, inSpatialRef):
+    outSpatialRef = osr.SpatialReference()
+    outSpatialRef.ImportFromEPSG(4326)
+    coordTrans = osr.CoordinateTransformation(inSpatialRef, outSpatialRef)
+    outMultipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
+    for polygon in inMultipolygon:
+        if inSpatialRef != outSpatialRef:
+            polygon.Transform(coordTrans)
+        outMultipolygon.AddGeometry(polygon)
 
-  outSpatialRef = osr.SpatialReference()
-  outSpatialRef.ImportFromEPSG(4326)
-  coordTrans = osr.CoordinateTransformation(inSpatialRef, outSpatialRef)
-  outMultipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
-  for polygon in inMultipolygon:
-    if inSpatialRef != outSpatialRef:
-      polygon.Transform(coordTrans)
-    outMultipolygon.AddGeometry(polygon)
+    return (outMultipolygon, outSpatialRef)
 
-  return (outMultipolygon, outSpatialRef)
 
 # Convert corner points from geographic to UTM projection
-def geometry_geo2proj(lat_max,lat_min,lon_max,lon_min):
-
-    zone = get_zone(lon_min,lon_max)
-    if (lat_min+lat_max)/2 > 0:
-        proj = ('326%02d' % int(zone))
+def geometry_geo2proj(lat_max, lat_min, lon_max, lon_min):
+    zone = get_zone(lon_min, lon_max)
+    if (lat_min + lat_max) / 2 > 0:
+        proj = '326%02d' % int(zone)
     else:
-        proj = ('327%02d' % int(zone))
+        proj = '327%02d' % int(zone)
 
     inSpatialRef = osr.SpatialReference()
     inSpatialRef.ImportFromEPSG(4326)
     outSpatialRef = osr.SpatialReference()
     outSpatialRef.ImportFromEPSG(int(proj))
-    coordTrans = osr.CoordinateTransformation(inSpatialRef,outSpatialRef)
+    coordTrans = osr.CoordinateTransformation(inSpatialRef, outSpatialRef)
 
     x1, y1, h = coordTrans.TransformPoint(lon_max, lat_min)
     x2, y2, h = coordTrans.TransformPoint(lon_min, lat_min)
     x3, y3, h = coordTrans.TransformPoint(lon_max, lat_max)
     x4, y4, h = coordTrans.TransformPoint(lon_min, lat_max)
 
-    y_min = min(y1,y2,y3,y4)
-    y_max = max(y1,y2,y3,y4)
-    x_min = min(x1,x2,x3,x4)
-    x_max = max(x1,x2,x3,x4)
+    y_min = min(y1, y2, y3, y4)
+    y_max = max(y1, y2, y3, y4)
+    x_min = min(x1, x2, x3, x4)
+    x_max = max(x1, x2, x3, x4)
 
     # false_easting = outSpatialRef.GetProjParm(osr.SRS_PP_FALSE_EASTING)
     false_northing = outSpatialRef.GetProjParm(osr.SRS_PP_FALSE_NORTHING)
@@ -500,434 +485,417 @@ def geometry_geo2proj(lat_max,lat_min,lon_max,lon_min):
 
 
 def reproject_corners(corners, posting, inEPSG, outEPSG):
+    # Reproject coordinates
+    inProj = osr.SpatialReference()
+    inProj.ImportFromEPSG(inEPSG)
+    outProj = osr.SpatialReference()
+    outProj.ImportFromEPSG(outEPSG)
+    transform = osr.CoordinateTransformation(inProj, outProj)
+    corners.Transform(transform)
 
-  # Reproject coordinates
-  inProj = osr.SpatialReference()
-  inProj.ImportFromEPSG(inEPSG)
-  outProj = osr.SpatialReference()
-  outProj.ImportFromEPSG(outEPSG)
-  transform = osr.CoordinateTransformation(inProj, outProj)
-  corners.Transform(transform)
+    # Get extent and round to even coordinates
+    (minX, maxX, minY, maxY) = corners.GetEnvelope()
+    # posting = inGT[1]
+    minX = np.ceil(minX / posting) * posting
+    minY = np.ceil(minY / posting) * posting
+    maxX = np.ceil(maxX / posting) * posting
+    maxY = np.ceil(maxY / posting) * posting
 
-  # Get extent and round to even coordinates
-  (minX, maxX, minY, maxY) = corners.GetEnvelope()
-  #posting = inGT[1]
-  minX = np.ceil(minX/posting)*posting
-  minY = np.ceil(minY/posting)*posting
-  maxX = np.ceil(maxX/posting)*posting
-  maxY = np.ceil(maxY/posting)*posting
+    # Add points to multiPoint
+    corners = ogr.Geometry(ogr.wkbMultiPoint)
+    ul = ogr.Geometry(ogr.wkbPoint)
+    ul.AddPoint(minX, maxY)
+    corners.AddGeometry(ul)
+    ll = ogr.Geometry(ogr.wkbPoint)
+    ll.AddPoint(minX, minY)
+    corners.AddGeometry(ll)
+    ur = ogr.Geometry(ogr.wkbPoint)
+    ur.AddPoint(maxX, maxY)
+    corners.AddGeometry(ur)
+    lr = ogr.Geometry(ogr.wkbPoint)
+    lr.AddPoint(maxX, minY)
+    corners.AddGeometry(lr)
 
-  # Add points to multiPoint
-  corners = ogr.Geometry(ogr.wkbMultiPoint)
-  ul = ogr.Geometry(ogr.wkbPoint)
-  ul.AddPoint(minX, maxY)
-  corners.AddGeometry(ul)
-  ll = ogr.Geometry(ogr.wkbPoint)
-  ll.AddPoint(minX, minY)
-  corners.AddGeometry(ll)
-  ur = ogr.Geometry(ogr.wkbPoint)
-  ur.AddPoint(maxX, maxY)
-  corners.AddGeometry(ur)
-  lr = ogr.Geometry(ogr.wkbPoint)
-  lr.AddPoint(maxX, minY)
-  corners.AddGeometry(lr)
-
-  return corners
+    return corners
 
 
 def reproject_extent(minX, maxX, minY, maxY, posting, inEPSG, outEPSG):
+    # Add points to multiPoint
+    corners = ogr.Geometry(ogr.wkbMultiPoint)
+    ul = ogr.Geometry(ogr.wkbPoint)
+    ul.AddPoint(minX, maxY)
+    corners.AddGeometry(ul)
+    ll = ogr.Geometry(ogr.wkbPoint)
+    ll.AddPoint(minX, minY)
+    corners.AddGeometry(ll)
+    ur = ogr.Geometry(ogr.wkbPoint)
+    ur.AddPoint(maxX, maxY)
+    corners.AddGeometry(ur)
+    lr = ogr.Geometry(ogr.wkbPoint)
+    lr.AddPoint(maxX, minY)
+    corners.AddGeometry(lr)
 
-  # Add points to multiPoint
-  corners = ogr.Geometry(ogr.wkbMultiPoint)
-  ul = ogr.Geometry(ogr.wkbPoint)
-  ul.AddPoint(minX, maxY)
-  corners.AddGeometry(ul)
-  ll = ogr.Geometry(ogr.wkbPoint)
-  ll.AddPoint(minX, minY)
-  corners.AddGeometry(ll)
-  ur = ogr.Geometry(ogr.wkbPoint)
-  ur.AddPoint(maxX, maxY)
-  corners.AddGeometry(ur)
-  lr = ogr.Geometry(ogr.wkbPoint)
-  lr.AddPoint(maxX, minY)
-  corners.AddGeometry(lr)
+    # Re-project corners
+    reproject_corners(corners, posting, inEPSG, outEPSG)
 
-  # Re-project corners
-  reproject_corners(corners, posting, inEPSG, outEPSG)
-
-  # Extract min/max values
-  return corners.GetEnvelope()
+    # Extract min/max values
+    return corners.GetEnvelope()
 
 
 def raster_meta(rasterFile):
+    raster = gdal.Open(rasterFile)
+    spatialRef = osr.SpatialReference()
+    spatialRef.ImportFromWkt(raster.GetProjectionRef())
+    gt = raster.GetGeoTransform()
+    shape = [raster.RasterYSize, raster.RasterXSize]
+    pixel = raster.GetMetadataItem('AREA_OR_POINT')
+    raster = None
 
-  raster = gdal.Open(rasterFile)
-  spatialRef = osr.SpatialReference()
-  spatialRef.ImportFromWkt(raster.GetProjectionRef())
-  gt = raster.GetGeoTransform()
-  shape = [ raster.RasterYSize, raster.RasterXSize ]
-  pixel = raster.GetMetadataItem('AREA_OR_POINT')
-  raster = None
-
-  return (spatialRef, gt, shape, pixel)
+    return (spatialRef, gt, shape, pixel)
 
 
 def overlapMask(meta, maskShape, invert, outFile):
+    ### Extract metadata
+    posting = meta['pixelSize']
+    # proj = meta['proj']
+    imageEPSG = meta['epsg']
+    multiBoundary = meta['boundary']
+    dataRows = meta['rows']
+    dataCols = meta['cols']
+    geoEPSG = 4326
 
-  ### Extract metadata
-  posting = meta['pixelSize']
-  # proj = meta['proj']
-  imageEPSG = meta['epsg']
-  multiBoundary = meta['boundary']
-  dataRows = meta['rows']
-  dataCols = meta['cols']
-  geoEPSG = 4326
+    ### Extract mask polygon
+    ogrDriver = ogr.GetDriverByName('ESRI Shapefile')
+    inShape = ogrDriver.Open(maskShape)
+    outLayer = inShape.GetLayer()
+    outProj = outLayer.GetSpatialRef()
+    outEPSG = int(outProj.GetAttrValue('AUTHORITY', 1))
+    if geoEPSG != outEPSG:
+        raise GeometryError(f'Expecting mask file with EPSG code: {geoEPSG}')
 
-  ### Extract mask polygon
-  ogrDriver = ogr.GetDriverByName('ESRI Shapefile')
-  inShape = ogrDriver.Open(maskShape)
-  outLayer = inShape.GetLayer()
-  outProj = outLayer.GetSpatialRef()
-  outEPSG = int(outProj.GetAttrValue('AUTHORITY', 1))
-  if geoEPSG != outEPSG:
-    raise GeometryError(f'Expecting mask file with EPSG code: {geoEPSG}')
+    ### Define re-projection from geographic to UTM
+    inProj = osr.SpatialReference()
+    inProj.ImportFromEPSG(4326)
+    outProj = osr.SpatialReference()
+    outProj.ImportFromEPSG(imageEPSG)
+    transform = osr.CoordinateTransformation(inProj, outProj)
 
-  ### Define re-projection from geographic to UTM
-  inProj = osr.SpatialReference()
-  inProj.ImportFromEPSG(4326)
-  outProj = osr.SpatialReference()
-  outProj.ImportFromEPSG(imageEPSG)
-  transform = osr.CoordinateTransformation(inProj, outProj)
+    ### Loop through features
+    for boundary in multiBoundary:
+        for feature in outLayer:
+            outMultipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
+            inMultiPolygon = feature.GetGeometryRef()
+            for polygon in inMultiPolygon:
+                overlap = boundary.Intersection(polygon)
+                if 'POLYGON' in overlap.ExportToWkt():
+                    overlap.Transform(transform)
+                    outMultipolygon.AddGeometry(overlap)
 
-  ### Loop through features
-  for boundary in multiBoundary:
-    for feature in outLayer:
-      outMultipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
-      inMultiPolygon = feature.GetGeometryRef()
-      for polygon in inMultiPolygon:
-        overlap = boundary.Intersection(polygon)
-        if 'POLYGON' in overlap.ExportToWkt():
-          overlap.Transform(transform)
-          outMultipolygon.AddGeometry(overlap)
+    ### Save intersection polygon in memory
+    spatialRef = osr.SpatialReference()
+    spatialRef.ImportFromEPSG(imageEPSG)
+    memDriver = ogr.GetDriverByName('Memory')
+    outVector = memDriver.CreateDataSource('mem')
+    outLayer = outVector.CreateLayer('', spatialRef, ogr.wkbMultiPolygon)
+    outLayer.CreateField(ogr.FieldDefn('id', ogr.OFTInteger))
+    definition = outLayer.GetLayerDefn()
+    outFeature = ogr.Feature(definition)
+    outFeature.SetField('id', 0)
+    geometry = ogr.CreateGeometryFromWkb(outMultipolygon.ExportToWkb())
+    outFeature.SetGeometry(geometry)
+    outLayer.CreateFeature(outFeature)
+    outFeature = None
 
-  ### Save intersection polygon in memory
-  spatialRef = osr.SpatialReference()
-  spatialRef.ImportFromEPSG(imageEPSG)
-  memDriver = ogr.GetDriverByName('Memory')
-  outVector = memDriver.CreateDataSource('mem')
-  outLayer = outVector.CreateLayer('', spatialRef, ogr.wkbMultiPolygon)
-  outLayer.CreateField(ogr.FieldDefn('id', ogr.OFTInteger))
-  definition = outLayer.GetLayerDefn()
-  outFeature = ogr.Feature(definition)
-  outFeature.SetField('id', 0)
-  geometry = ogr.CreateGeometryFromWkb(outMultipolygon.ExportToWkb())
-  outFeature.SetGeometry(geometry)
-  outLayer.CreateFeature(outFeature)
-  outFeature = None
+    ### Calculate extent
+    (aoiMinX, aoiMaxX, aoiMinY, aoiMaxY) = outLayer.GetExtent()
+    aoiLines = int(np.rint((aoiMaxY - aoiMinY) / posting))
+    aoiSamples = int(np.rint((aoiMaxX - aoiMinX) / posting))
+    maskGeoTrans = (aoiMinX, posting, 0, aoiMaxY, 0, -posting)
 
-  ### Calculate extent
-  (aoiMinX, aoiMaxX, aoiMinY, aoiMaxY) = outLayer.GetExtent()
-  aoiLines = int(np.rint((aoiMaxY - aoiMinY)/posting))
-  aoiSamples = int(np.rint((aoiMaxX - aoiMinX)/posting))
-  maskGeoTrans = (aoiMinX, posting, 0, aoiMaxY, 0, -posting)
+    ### Rasterize mask polygon
+    gdalDriver = gdal.GetDriverByName('MEM')
+    outRaster = gdalDriver.Create('', aoiSamples, aoiLines, 1, gdal.GDT_Float32)
+    outRaster.SetGeoTransform((aoiMinX, posting, 0, aoiMaxY, 0, -posting))
+    outRaster.SetProjection(outProj.ExportToWkt())
+    outBand = outRaster.GetRasterBand(1)
+    outBand.SetNoDataValue(0)
+    outBand.FlushCache()
+    gdal.RasterizeLayer(outRaster, [1], outLayer, burn_values=[1])
+    mask = outRaster.GetRasterBand(1).ReadAsArray()
+    outVector = None
+    outRaster = None
 
-  ### Rasterize mask polygon
-  gdalDriver = gdal.GetDriverByName('MEM')
-  outRaster = gdalDriver.Create('', aoiSamples, aoiLines, 1, gdal.GDT_Float32)
-  outRaster.SetGeoTransform((aoiMinX, posting, 0, aoiMaxY, 0, -posting))
-  outRaster.SetProjection(outProj.ExportToWkt())
-  outBand = outRaster.GetRasterBand(1)
-  outBand.SetNoDataValue(0)
-  outBand.FlushCache()
-  gdal.RasterizeLayer(outRaster, [1], outLayer, burn_values=[1])
-  mask = outRaster.GetRasterBand(1).ReadAsArray()
-  outVector = None
-  outRaster = None
+    ### Invert mask (if requested)
+    if invert == True:
+        mask = 1.0 - mask
 
-  ### Invert mask (if requested)
-  if invert == True:
-    mask = 1.0 - mask
+    ### Final adjustments
+    mask = mask[:dataRows, :dataCols]
+    mask[mask == 0] = np.nan
 
-  ### Final adjustments
-  mask = mask[:dataRows,:dataCols]
-  mask[mask==0] = np.nan
-
-  return (mask, maskGeoTrans)
+    return (mask, maskGeoTrans)
 
 
 def apply_mask(data, dataGeoTrans, mask, maskGeoTrans):
+    (dataRows, dataCols) = data.shape
+    dataOriginX = dataGeoTrans[0]
+    dataOriginY = dataGeoTrans[3]
+    # dataPixelSize = dataGeoTrans[1]
+    (maskRows, maskCols) = mask.shape
+    maskOriginX = maskGeoTrans[0]
+    maskOriginY = maskGeoTrans[3]
+    maskPixelSize = maskGeoTrans[1]
+    offsetX = int(np.rint((maskOriginX - dataOriginX) / maskPixelSize))
+    offsetY = int(np.rint((dataOriginY - maskOriginY) / maskPixelSize))
+    data = data[offsetY : maskRows + offsetY, offsetX : maskCols + offsetX]
+    data *= mask
 
-  (dataRows, dataCols) = data.shape
-  dataOriginX = dataGeoTrans[0]
-  dataOriginY = dataGeoTrans[3]
-  # dataPixelSize = dataGeoTrans[1]
-  (maskRows, maskCols) = mask.shape
-  maskOriginX = maskGeoTrans[0]
-  maskOriginY = maskGeoTrans[3]
-  maskPixelSize = maskGeoTrans[1]
-  offsetX = int(np.rint((maskOriginX - dataOriginX)/maskPixelSize))
-  offsetY = int(np.rint((dataOriginY - maskOriginY)/maskPixelSize))
-  data = data[offsetY:maskRows+offsetY,offsetX:maskCols+offsetX]
-  data *= mask
-
-  return data
+    return data
 
 
 def geotiff2boundary_ext(inGeotiff, maskFile, geographic):
+    # Extract metadata
+    (spatialRef, gt, shape, pixel) = raster_meta(inGeotiff)
+    epsg = int(spatialRef.GetAttrValue('AUTHORITY', 1))
+    (data, colFirst, rowsFirst, geoTrans, proj) = geotiff2boundary_mask(inGeotiff, epsg, None)
+    (rows, cols) = data.shape
 
-  # Extract metadata
-  (spatialRef, gt, shape, pixel) = raster_meta(inGeotiff)
-  epsg = int(spatialRef.GetAttrValue('AUTHORITY', 1))
-  (data, colFirst, rowsFirst, geoTrans, proj) = \
-    geotiff2boundary_mask(inGeotiff, epsg, None)
-  (rows, cols) = data.shape
+    # Save in mask file (if defined)
+    if maskFile is not None:
+        gdalDriver = gdal.GetDriverByName('GTiff')
+        outRaster = gdalDriver.Create(maskFile, rows, cols, 1, gdal.GDT_Byte)
+        outRaster.SetGeoTransform(geoTrans)
+        outRaster.SetProjection(proj.ExportToWkt())
+        outBand = outRaster.GetRasterBand(1)
+        outBand.WriteArray(data)
+        outRaster = None
 
-  # Save in mask file (if defined)
-  if maskFile is not None:
-    gdalDriver = gdal.GetDriverByName('GTiff')
-    outRaster = gdalDriver.Create(maskFile, rows, cols, 1, gdal.GDT_Byte)
+    # Save in memory
+    gdalDriver = gdal.GetDriverByName('Mem')
+    outRaster = gdalDriver.Create('out', rows, cols, 1, gdal.GDT_Byte)
     outRaster.SetGeoTransform(geoTrans)
     outRaster.SetProjection(proj.ExportToWkt())
     outBand = outRaster.GetRasterBand(1)
     outBand.WriteArray(data)
+    data = None
+
+    # Polygonize the raster image
+    inBand = outRaster.GetRasterBand(1)
+    ogrDriver = ogr.GetDriverByName('Memory')
+    outVector = ogrDriver.CreateDataSource('out')
+    outLayer = outVector.CreateLayer('boundary', srs=proj)
+    fieldDefinition = ogr.FieldDefn('ID', ogr.OFTInteger)
+    outLayer.CreateField(fieldDefinition)
+    gdal.Polygonize(inBand, inBand, outLayer, 0, [], None)
     outRaster = None
 
-  # Save in memory
-  gdalDriver = gdal.GetDriverByName('Mem')
-  outRaster = gdalDriver.Create('out', rows, cols, 1, gdal.GDT_Byte)
-  outRaster.SetGeoTransform(geoTrans)
-  outRaster.SetProjection(proj.ExportToWkt())
-  outBand = outRaster.GetRasterBand(1)
-  outBand.WriteArray(data)
-  data = None
+    # Extract geometry from layer
+    inSpatialRef = outLayer.GetSpatialRef()
+    multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
+    for outFeature in outLayer:
+        geometry = outFeature.GetGeometryRef()
+        multipolygon.AddGeometry(geometry)
+        outFeature = None
+    outLayer = None
 
-  # Polygonize the raster image
-  inBand = outRaster.GetRasterBand(1)
-  ogrDriver = ogr.GetDriverByName('Memory')
-  outVector = ogrDriver.CreateDataSource('out')
-  outLayer = outVector.CreateLayer('boundary', srs=proj)
-  fieldDefinition = ogr.FieldDefn('ID', ogr.OFTInteger)
-  outLayer.CreateField(fieldDefinition)
-  gdal.Polygonize(inBand, inBand, outLayer, 0, [], None)
-  outRaster = None
-
-  # Extract geometry from layer
-  inSpatialRef = outLayer.GetSpatialRef()
-  multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
-  for outFeature in outLayer:
-    geometry = outFeature.GetGeometryRef()
-    multipolygon.AddGeometry(geometry)
-    outFeature = None
-  outLayer = None
-
-  # Convert geometry from projected to geographic coordinates (if requested)
-  if geographic == True:
-    (multipolygon, outSpatialRef) = \
-      geometry_proj2geo(multipolygon, inSpatialRef)
-    return (multipolygon, outSpatialRef)
-  else:
-    return (multipolygon, inSpatialRef)
+    # Convert geometry from projected to geographic coordinates (if requested)
+    if geographic == True:
+        (multipolygon, outSpatialRef) = geometry_proj2geo(multipolygon, inSpatialRef)
+        return (multipolygon, outSpatialRef)
+    else:
+        return (multipolygon, inSpatialRef)
 
 
 def geotiff2boundary(inGeotiff, maskFile):
-
-  return geotiff2boundary_ext(inGeotiff, maskFile, False)
+    return geotiff2boundary_ext(inGeotiff, maskFile, False)
 
 
 def geotiff2boundary_geo(inGeotiff, maskFile):
-
-  return geotiff2boundary_ext(inGeotiff, maskFile, True)
+    return geotiff2boundary_ext(inGeotiff, maskFile, True)
 
 
 # Get polygon for a tile
 def get_tile_geometry(tile, step):
+    # Extract corners
+    xmin = int(tile[1:3])
+    ymin = int(tile[4:7])
+    if tile[0] == 'S':
+        xmin = -xmin
+    if tile[3] == 'W':
+        ymin = -ymin
+    xmax = xmin + step
+    ymax = ymin + step
 
-  # Extract corners
-  xmin = int(tile[1:3])
-  ymin = int(tile[4:7])
-  if tile[0] == 'S':
-    xmin = -xmin
-  if tile[3] == 'W':
-    ymin = -ymin
-  xmax = xmin + step
-  ymax = ymin + step
+    # Create geometry
+    ring = ogr.Geometry(ogr.wkbLinearRing)
+    ring.AddPoint_2D(ymax, xmin)
+    ring.AddPoint_2D(ymax, xmax)
+    ring.AddPoint_2D(ymin, xmax)
+    ring.AddPoint_2D(ymin, xmin)
+    ring.AddPoint_2D(ymax, xmin)
+    polygon = ogr.Geometry(ogr.wkbPolygon)
+    polygon.AddGeometry(ring)
 
-  # Create geometry
-  ring = ogr.Geometry(ogr.wkbLinearRing)
-  ring.AddPoint_2D(ymax, xmin)
-  ring.AddPoint_2D(ymax, xmax)
-  ring.AddPoint_2D(ymin, xmax)
-  ring.AddPoint_2D(ymin, xmin)
-  ring.AddPoint_2D(ymax, xmin)
-  polygon = ogr.Geometry(ogr.wkbPolygon)
-  polygon.AddGeometry(ring)
-
-  return polygon
+    return polygon
 
 
 # Get tile names
 def get_tile_names(minLat, maxLat, minLon, maxLon, step):
-
-  tiles = []
-  for i in range(minLon, maxLon, step):
-    for k in range(minLat, maxLat, step):
-      eastwest = 'W' if i<0 else 'E'
-      northsouth = 'S' if k<0 else 'N'
-      tile = ('%s%02d%s%03d' % (northsouth, abs(k), eastwest, abs(i)))
-      tiles.append(tile)
-  return tiles
+    tiles = []
+    for i in range(minLon, maxLon, step):
+        for k in range(minLat, maxLat, step):
+            eastwest = 'W' if i < 0 else 'E'
+            northsouth = 'S' if k < 0 else 'N'
+            tile = '%s%02d%s%03d' % (northsouth, abs(k), eastwest, abs(i))
+            tiles.append(tile)
+    return tiles
 
 
 # Get tiles extent
 def get_tiles_extent(tiles, step):
+    minLat = 90
+    maxLat = -90
+    minLon = 180
+    maxLon = -180
+    for tile in tiles:
+        xmin = int(tile[1:3])
+        ymin = int(tile[4:7])
+        if tile[0] == 'S':
+            xmin = -xmin
+        if tile[3] == 'W':
+            ymin = -ymin
+        if xmin < minLat:
+            minLat = xmin
+        if xmin > maxLat:
+            maxLat = xmin
+        if ymin < minLon:
+            minLon = ymin
+        if ymin > maxLon:
+            maxLon = ymin
+    maxLat += step
+    maxLon += step
 
-  minLat = 90
-  maxLat = -90
-  minLon = 180
-  maxLon = -180
-  for tile in tiles:
-    xmin = int(tile[1:3])
-    ymin = int(tile[4:7])
-    if tile[0] == 'S':
-      xmin = -xmin
-    if tile[3] == 'W':
-      ymin = -ymin
-    if xmin < minLat:
-      minLat = xmin
-    if xmin > maxLat:
-      maxLat = xmin
-    if ymin < minLon:
-      minLon = ymin
-    if ymin > maxLon:
-      maxLon = ymin
-  maxLat += step
-  maxLon += step
-
-  return (minLat, maxLat, minLon, maxLon)
+    return (minLat, maxLat, minLon, maxLon)
 
 
 # Generate a global tile shapefile
 def generate_tile_shape(shapeFile, minLat, maxLat, minLon, maxLon, step):
+    # General setup for shapefile
+    driver = ogr.GetDriverByName('ESRI Shapefile')
+    if os.path.exists(shapeFile):
+        driver.DeleteDataSource(shapeFile)
+    shapeData = driver.CreateDataSource(shapeFile)
 
-  # General setup for shapefile
-  driver = ogr.GetDriverByName('ESRI Shapefile')
-  if os.path.exists(shapeFile):
-    driver.DeleteDataSource(shapeFile)
-  shapeData = driver.CreateDataSource(shapeFile)
+    # Define layer and attributes
+    spatialReference = osr.SpatialReference()
+    spatialReference.ImportFromEPSG(4326)
+    layer = shapeData.CreateLayer(shapeFile, spatialReference, ogr.wkbPolygon)
+    fieldname = ogr.FieldDefn('tile', ogr.OFTString)
+    fieldname.SetWidth(10)
+    layer.CreateField(fieldname)
 
-  # Define layer and attributes
-  spatialReference = osr.SpatialReference()
-  spatialReference.ImportFromEPSG(4326)
-  layer = shapeData.CreateLayer(shapeFile, spatialReference, ogr.wkbPolygon)
-  fieldname = ogr.FieldDefn('tile', ogr.OFTString)
-  fieldname.SetWidth(10)
-  layer.CreateField(fieldname)
+    # Going through the tiles
+    tiles = get_tile_names(minLat, maxLat, minLon, maxLon, step)
+    for tile in tiles:
+        geometry = get_tile_geometry(tile, step)
+        tileGeometry = geometry.ExportToWkt()
+        feature = ogr.Feature(layer.GetLayerDefn())
+        feature.SetField('tile', tile)
 
-  # Going through the tiles
-  tiles = get_tile_names(minLat, maxLat, minLon, maxLon, step)
-  for tile in tiles:
-    geometry = get_tile_geometry(tile, step)
-    tileGeometry = geometry.ExportToWkt()
-    feature = ogr.Feature(layer.GetLayerDefn())
-    feature.SetField('tile', tile)
+        # Define geometry as polygon
+        geom = ogr.CreateGeometryFromWkt(tileGeometry)
+        if geom:
+            feature.SetGeometry(geom)
+            layer.CreateFeature(feature)
+            feature.Destroy()
 
-    # Define geometry as polygon
-    geom = ogr.CreateGeometryFromWkt(tileGeometry)
-    if geom:
-      feature.SetGeometry(geom)
-      layer.CreateFeature(feature)
-      feature.Destroy()
-
-  shapeData.Destroy()
+    shapeData.Destroy()
 
 
 # Generate a shapefile from a CSV list file
 def list2shape(csvFile, shapeFile):
+    # Set up shapefile attributes
+    fields = []
+    field = {}
+    values = []
+    field['name'] = 'granule'
+    field['type'] = ogr.OFTString
+    field['width'] = 254
+    fields.append(field)
 
-  # Set up shapefile attributes
-  fields = []
-  field = {}
-  values = []
-  field['name'] = 'granule'
-  field['type'] = ogr.OFTString
-  field['width'] = 254
-  fields.append(field)
+    files = [line.strip() for line in open(csvFile)]
+    for file in files:
+        data = gdal.Open(file, GA_ReadOnly)
+        if data is not None and data.GetDriver().LongName == 'GeoTIFF':
+            print('Reading %s ...' % file)
+            # Generate GeoTIFF boundary geometry
+            data = None
+            (geometry, spatialRef) = geotiff2boundary(file, None)
 
-  files = [line.strip() for line in open(csvFile)]
-  for file in files:
-    data = gdal.Open(file, GA_ReadOnly)
-    if data is not None and data.GetDriver().LongName == 'GeoTIFF':
+            # Simplify the geometry - only works with GDAL 1.8.0
+            # geometry = geometry.Simplify(float(tolerance))
 
-      print('Reading %s ...' % file)
-      # Generate GeoTIFF boundary geometry
-      data = None
-      (geometry, spatialRef) = geotiff2boundary(file, None)
+            # Add granule name and geometry
+            base = os.path.basename(file)
+            granule = os.path.splitext(base)[0]
+            value = {}
+            value['granule'] = granule
+            value['geometry'] = geometry
+            values.append(value)
 
-      # Simplify the geometry - only works with GDAL 1.8.0
-      #geometry = geometry.Simplify(float(tolerance))
-
-      # Add granule name and geometry
-      base = os.path.basename(file)
-      granule = os.path.splitext(base)[0]
-      value = {}
-      value['granule'] = granule
-      value['geometry'] = geometry
-      values.append(value)
-
-  # Write geometry to shapefile
-  merge = False
-  geometry2shape(fields, values, spatialRef, merge, shapeFile)
+    # Write geometry to shapefile
+    merge = False
+    geometry2shape(fields, values, spatialRef, merge, shapeFile)
 
 
 # Determine the tiles for an area of interest
 def aoi2tiles(aoiGeometry):
+    # Determine the bounding box
+    envelope = aoiGeometry.GetEnvelope()
+    west = int(envelope[0] - 0.5)
+    east = int(envelope[1] + 1.5)
+    south = int(envelope[2] - 0.5)
+    north = int(envelope[3] + 1.5)
 
-  # Determine the bounding box
-  envelope = aoiGeometry.GetEnvelope()
-  west = int(envelope[0] - 0.5)
-  east = int(envelope[1] + 1.5)
-  south = int(envelope[2] - 0.5)
-  north = int(envelope[3] + 1.5)
+    # Walk through the potential tiles and add the required on to the geometry
+    tiles = []
+    multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
+    for i in range(west, east):
+        for k in range(south, north):
+            eastwest = 'W' if i < 0 else 'E'
+            northsouth = 'S' if k < 0 else 'N'
+            tile = '%s%02d%s%03d' % (northsouth, abs(k), eastwest, abs(i))
+            polygon = get_tile_geometry(tile, 1)
+            intersection = polygon.Intersection(aoiGeometry)
+            if intersection is not None:
+                multipolygon.AddGeometry(polygon)
+                tiles.append(tile)
 
-  # Walk through the potential tiles and add the required on to the geometry
-  tiles = []
-  multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
-  for i in range(west, east):
-    for k in range(south, north):
-      eastwest = 'W' if i<0 else 'E'
-      northsouth = 'S' if k<0 else 'N'
-      tile = ('%s%02d%s%03d' % (northsouth, abs(k), eastwest, abs(i)))
-      polygon = get_tile_geometry(tile, 1)
-      intersection = polygon.Intersection(aoiGeometry)
-      if intersection is not None:
-        multipolygon.AddGeometry(polygon)
-        tiles.append(tile)
+    return (tiles, multipolygon)
 
-  return (tiles, multipolygon)
 
 def get_latlon_extent(filename):
-  src = gdal.Open(filename)
-  ulx, xres, xskew, uly, yskew, yres  = src.GetGeoTransform()
-  lrx = ulx + (src.RasterXSize * xres)
-  lry = uly + (src.RasterYSize * yres)
+    src = gdal.Open(filename)
+    ulx, xres, xskew, uly, yskew, yres = src.GetGeoTransform()
+    lrx = ulx + (src.RasterXSize * xres)
+    lry = uly + (src.RasterYSize * yres)
 
-  source = osr.SpatialReference()
-  source.ImportFromWkt(src.GetProjection())
+    source = osr.SpatialReference()
+    source.ImportFromWkt(src.GetProjection())
 
-  target = osr.SpatialReference()
-  target.ImportFromEPSG(4326)
+    target = osr.SpatialReference()
+    target.ImportFromEPSG(4326)
 
-  transform = osr.CoordinateTransformation(source, target)
+    transform = osr.CoordinateTransformation(source, target)
 
-  lon1, lat1, h = transform.TransformPoint(ulx, uly)
-  lon2, lat2, h = transform.TransformPoint(lrx, uly)
-  lon3, lat3, h = transform.TransformPoint(ulx, lry)
-  lon4, lat4, h = transform.TransformPoint(lrx, lry)
+    lon1, lat1, h = transform.TransformPoint(ulx, uly)
+    lon2, lat2, h = transform.TransformPoint(lrx, uly)
+    lon3, lat3, h = transform.TransformPoint(ulx, lry)
+    lon4, lat4, h = transform.TransformPoint(lrx, lry)
 
-  lat_min = min(lat1,lat2,lat3,lat4)
-  lat_max = max(lat1,lat2,lat3,lat4)
-  lon_min = min(lon1,lon2,lon3,lon4)
-  lon_max = max(lon1,lon2,lon3,lon4)
+    lat_min = min(lat1, lat2, lat3, lat4)
+    lat_max = max(lat1, lat2, lat3, lat4)
+    lon_min = min(lon1, lon2, lon3, lon4)
+    lon_max = max(lon1, lon2, lon3, lon4)
 
-  return lat_min, lat_max, lon_min, lon_max
-
+    return lat_min, lat_max, lon_min, lon_max

--- a/src/hyp3lib/asf_geometry.py
+++ b/src/hyp3lib/asf_geometry.py
@@ -61,18 +61,18 @@ def geotiff2boundary_mask(inGeotiff, tsEPSG, threshold, use_closing=True):
     data = inBand.ReadAsArray()
     minValue = np.min(data)
 
-    ### Check for black fill
+    # Check for black fill
     if minValue > 0:
         data /= data
         colFirst = 0
         rowFirst = 0
     else:
-        data[np.isnan(data) == True] = noDataValue
+        data[np.isnan(data) is True] = noDataValue
         if threshold is not None:
             print('Applying threshold ({0}) ...'.format(threshold))
             data[data < np.float(threshold)] = noDataValue
         if np.isnan(noDataValue):
-            data[np.isnan(data) == False] = 1
+            data[np.isnan(data) is False] = 1
         else:
             data[data > noDataValue] = 1
         if use_closing:
@@ -126,7 +126,7 @@ def cut_blackfill(data, geoTrans):
     colFirst = rowProfile.index(1)
     originX += colFirst * pixelSize
     originY -= rowFirst * pixelSize
-    data = data[rowFirst : rows + rowFirst, colFirst : cols + colFirst]
+    data = data[rowFirst:rows + rowFirst, colFirst:cols + colFirst]
     geoTrans = (originX, pixelSize, 0, originY, 0, -pixelSize)
 
     return (data, colFirst, rowFirst, geoTrans)
@@ -245,7 +245,7 @@ def geometry2shape(fields, values, spatialRef, merge, shapeFile):
             fieldDefinition.SetPrecision(8)
         outLayer.CreateField(fieldDefinition)
     featureDefinition = outLayer.GetLayerDefn()
-    if merge == True:
+    if merge is True:
         combine = ogr.Geometry(ogr.wkbMultiPolygon)
         for value in values:
             combine = combine.Union(value['geometry'])
@@ -283,7 +283,7 @@ def data_geometry2shape_ext(data, fields, values, spatialRef, geoTrans, classes,
     originY = geoTrans[3] + 10 * pixelSize
     geoTrans = (originX, pixelSize, 0, originY, 0, -pixelSize)
     mask = np.zeros((rows + 20, cols + 20), dtype=np.float32)
-    mask[10 : rows + 10, 10 : cols + 10] = data
+    mask[10:rows + 10, 10:cols + 10] = data
     data = mask
 
     # Save in memory
@@ -342,7 +342,7 @@ def data_geometry2shape_ext(data, fields, values, spatialRef, geoTrans, classes,
                     outFeature.SetField('size', classes[ii]['class'])
         centroid = geometry.Centroid().ExportToWkt()
         outFeature.SetField('centroid', centroid)
-        if fill == False and area > threshold:
+        if fill is False and area > threshold:
             outLayer.SetFeature(outFeature)
         else:
             outLayer.DeleteFeature(outFeature.GetFID())
@@ -555,7 +555,7 @@ def raster_meta(rasterFile):
 
 
 def overlapMask(meta, maskShape, invert, outFile):
-    ### Extract metadata
+    # Extract metadata
     posting = meta['pixelSize']
     # proj = meta['proj']
     imageEPSG = meta['epsg']
@@ -564,7 +564,7 @@ def overlapMask(meta, maskShape, invert, outFile):
     dataCols = meta['cols']
     geoEPSG = 4326
 
-    ### Extract mask polygon
+    # Extract mask polygon
     ogrDriver = ogr.GetDriverByName('ESRI Shapefile')
     inShape = ogrDriver.Open(maskShape)
     outLayer = inShape.GetLayer()
@@ -573,14 +573,14 @@ def overlapMask(meta, maskShape, invert, outFile):
     if geoEPSG != outEPSG:
         raise GeometryError(f'Expecting mask file with EPSG code: {geoEPSG}')
 
-    ### Define re-projection from geographic to UTM
+    # Define re-projection from geographic to UTM
     inProj = osr.SpatialReference()
     inProj.ImportFromEPSG(4326)
     outProj = osr.SpatialReference()
     outProj.ImportFromEPSG(imageEPSG)
     transform = osr.CoordinateTransformation(inProj, outProj)
 
-    ### Loop through features
+    # Loop through features
     for boundary in multiBoundary:
         for feature in outLayer:
             outMultipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
@@ -591,7 +591,7 @@ def overlapMask(meta, maskShape, invert, outFile):
                     overlap.Transform(transform)
                     outMultipolygon.AddGeometry(overlap)
 
-    ### Save intersection polygon in memory
+    # Save intersection polygon in memory
     spatialRef = osr.SpatialReference()
     spatialRef.ImportFromEPSG(imageEPSG)
     memDriver = ogr.GetDriverByName('Memory')
@@ -606,13 +606,13 @@ def overlapMask(meta, maskShape, invert, outFile):
     outLayer.CreateFeature(outFeature)
     outFeature = None
 
-    ### Calculate extent
+    # Calculate extent
     (aoiMinX, aoiMaxX, aoiMinY, aoiMaxY) = outLayer.GetExtent()
     aoiLines = int(np.rint((aoiMaxY - aoiMinY) / posting))
     aoiSamples = int(np.rint((aoiMaxX - aoiMinX) / posting))
     maskGeoTrans = (aoiMinX, posting, 0, aoiMaxY, 0, -posting)
 
-    ### Rasterize mask polygon
+    # Rasterize mask polygon
     gdalDriver = gdal.GetDriverByName('MEM')
     outRaster = gdalDriver.Create('', aoiSamples, aoiLines, 1, gdal.GDT_Float32)
     outRaster.SetGeoTransform((aoiMinX, posting, 0, aoiMaxY, 0, -posting))
@@ -625,11 +625,11 @@ def overlapMask(meta, maskShape, invert, outFile):
     outVector = None
     outRaster = None
 
-    ### Invert mask (if requested)
-    if invert == True:
+    # Invert mask (if requested)
+    if invert is True:
         mask = 1.0 - mask
 
-    ### Final adjustments
+    # Final adjustments
     mask = mask[:dataRows, :dataCols]
     mask[mask == 0] = np.nan
 
@@ -647,7 +647,7 @@ def apply_mask(data, dataGeoTrans, mask, maskGeoTrans):
     maskPixelSize = maskGeoTrans[1]
     offsetX = int(np.rint((maskOriginX - dataOriginX) / maskPixelSize))
     offsetY = int(np.rint((dataOriginY - maskOriginY) / maskPixelSize))
-    data = data[offsetY : maskRows + offsetY, offsetX : maskCols + offsetX]
+    data = data[offsetY:maskRows + offsetY, offsetX:maskCols + offsetX]
     data *= mask
 
     return data
@@ -699,7 +699,7 @@ def geotiff2boundary_ext(inGeotiff, maskFile, geographic):
     outLayer = None
 
     # Convert geometry from projected to geographic coordinates (if requested)
-    if geographic == True:
+    if geographic is True:
         (multipolygon, outSpatialRef) = geometry_proj2geo(multipolygon, inSpatialRef)
         return (multipolygon, outSpatialRef)
     else:

--- a/src/hyp3lib/asf_time_series.py
+++ b/src/hyp3lib/asf_time_series.py
@@ -16,437 +16,421 @@ tolerance = 0.00005
 
 
 def initializeNetcdf(ncFile, meta):
+    dataset = nc.Dataset(ncFile, 'w', format='NETCDF4')
 
-  dataset = nc.Dataset(ncFile, 'w', format='NETCDF4')
+    ### Define global attributes
+    dataset.Conventions = 'CF-1.7'
+    dataset.institution = meta['institution']
+    dataset.title = meta['title']
+    dataset.source = meta['source']
+    dataset.comment = meta['comment']
+    dataset.reference = meta['reference']
+    timestamp = datetime.utcnow().isoformat() + 'Z'
+    dataset.history = '{0}: netCDF file created'.format(timestamp)
+    dataset.featureType = 'timeSeries'
 
-  ### Define global attributes
-  dataset.Conventions = ('CF-1.7')
-  dataset.institution = meta['institution']
-  dataset.title = meta['title']
-  dataset.source = meta['source']
-  dataset.comment = meta['comment']
-  dataset.reference = meta['reference']
-  timestamp = datetime.utcnow().isoformat() + 'Z'
-  dataset.history = ('{0}: netCDF file created'.format(timestamp))
-  dataset.featureType = ('timeSeries')
+    ### Create dimensions
+    dataset.createDimension('xgrid', meta['cols'])
+    dataset.createDimension('ygrid', meta['rows'])
+    dataset.createDimension('time', None)
+    dataset.createDimension('nchar', 100)
 
-  ### Create dimensions
-  dataset.createDimension('xgrid', meta['cols'])
-  dataset.createDimension('ygrid', meta['rows'])
-  dataset.createDimension('time', None)
-  dataset.createDimension('nchar', 100)
+    ### Create variables - time, coordinates, values
+    ## time
+    time = dataset.createVariable('time', np.float32, ('time',))
+    time.axis = 'T'
+    time.long_name = 'serial date'
+    time.standard_name = 'time'
+    time.units = 'seconds since {0}'.format(meta['refTime'])
+    time.calendar = 'gregorian'
+    time.fill_value = 0
+    time.reference = 'center time of image'
 
-  ### Create variables - time, coordinates, values
-  ## time
-  time = dataset.createVariable('time', np.float32, ('time',))
-  time.axis = ('T')
-  time.long_name = ('serial date')
-  time.standard_name = ('time')
-  time.units = ('seconds since {0}'.format(meta['refTime']))
-  time.calendar = 'gregorian'
-  time.fill_value = 0
-  time.reference = ('center time of image')
+    ## map projection
+    projSpatialRef = osr.SpatialReference()
+    projSpatialRef.ImportFromEPSG(int(meta['epsg']))
+    wkt = projSpatialRef.ExportToWkt()
+    projection = dataset.createVariable('Transverse_Mercator', 'S1')
+    projection.grid_mapping_name = 'transverse_mercator'
+    projection.crs_wkt = wkt
+    projection.scale_factor_at_centeral_meridian = projSpatialRef.GetProjParm(osr.SRS_PP_SCALE_FACTOR)
+    projection.longitude_of_central_meridian = projSpatialRef.GetProjParm(osr.SRS_PP_CENTRAL_MERIDIAN)
+    projection.latitude_of_projection_origin = projSpatialRef.GetProjParm(osr.SRS_PP_LATITUDE_OF_ORIGIN)
+    projection.false_easting = projSpatialRef.GetProjParm(osr.SRS_PP_FALSE_EASTING)
+    projection.false_northing = projSpatialRef.GetProjParm(osr.SRS_PP_FALSE_NORTHING)
+    projection.projection_x_coordinate = 'xgrid'
+    projection.projection_y_coordinate = 'ygrid'
+    projection.units = 'meters'
 
-  ## map projection
-  projSpatialRef = osr.SpatialReference()
-  projSpatialRef.ImportFromEPSG(int(meta['epsg']))
-  wkt = projSpatialRef.ExportToWkt()
-  projection = dataset.createVariable('Transverse_Mercator', 'S1')
-  projection.grid_mapping_name = ('transverse_mercator')
-  projection.crs_wkt = wkt
-  projection.scale_factor_at_centeral_meridian = \
-    projSpatialRef.GetProjParm(osr.SRS_PP_SCALE_FACTOR)
-  projection.longitude_of_central_meridian = \
-    projSpatialRef.GetProjParm(osr.SRS_PP_CENTRAL_MERIDIAN)
-  projection.latitude_of_projection_origin = \
-    projSpatialRef.GetProjParm(osr.SRS_PP_LATITUDE_OF_ORIGIN)
-  projection.false_easting = \
-    projSpatialRef.GetProjParm(osr.SRS_PP_FALSE_EASTING)
-  projection.false_northing = \
-    projSpatialRef.GetProjParm(osr.SRS_PP_FALSE_NORTHING)
-  projection.projection_x_coordinate = ('xgrid')
-  projection.projection_y_coordinate = ('ygrid')
-  projection.units = ('meters')
+    ## coordinate: x grid
+    xgrid = dataset.createVariable('xgrid', np.float32, ('xgrid'))
+    xgrid.axis = 'X'
+    xgrid.long_name = 'projection_grid_y_center'
+    xgrid.standard_name = 'projection_y_coordinate'
+    xgrid.units = 'meters'
+    xgrid.fill_value = np.nan
 
-  ## coordinate: x grid
-  xgrid = dataset.createVariable('xgrid', np.float32, ('xgrid'))
-  xgrid.axis = ('X')
-  xgrid.long_name = ('projection_grid_y_center')
-  xgrid.standard_name = ('projection_y_coordinate')
-  xgrid.units = ('meters')
-  xgrid.fill_value = np.nan
+    ## coordinate: y grid
+    ygrid = dataset.createVariable('ygrid', np.float32, ('ygrid'))
+    ygrid.axis = 'Y'
+    ygrid.long_name = 'projection_grid_x_center'
+    ygrid.standard_name = 'projection_x_coordinate'
+    ygrid.units = 'meters'
+    ygrid.fill_value = np.nan
 
-  ## coordinate: y grid
-  ygrid = dataset.createVariable('ygrid', np.float32, ('ygrid'))
-  ygrid.axis = ('Y')
-  ygrid.long_name = ('projection_grid_x_center')
-  ygrid.standard_name = ('projection_x_coordinate')
-  ygrid.units = ('meters')
-  ygrid.fill_value = np.nan
+    ## image
+    image = dataset.createVariable('image', np.float32, ('time', 'ygrid', 'xgrid'), zlib=True)
+    image.long_name = meta['imgLongName']
+    image.units = meta['imgUnits']
+    image.fill_value = meta['imgNoData']
 
-  ## image
-  image = dataset.createVariable('image', np.float32, \
-    ('time', 'ygrid', 'xgrid'), zlib=True)
-  image.long_name = meta['imgLongName']
-  image.units = meta['imgUnits']
-  image.fill_value = meta['imgNoData']
+    ## name
+    name = dataset.createVariable('granule', 'S1', ('time', 'nchar'))
+    name.long_name = 'name of the granule'
 
-  ## name
-  name = dataset.createVariable('granule', 'S1', ('time', 'nchar'))
-  name.long_name = 'name of the granule'
+    ### Fill in coordinates
+    xCoordinate = np.arange(meta['minX'], meta['maxX'], meta['pixelSize'])
+    xgrid[:] = xCoordinate
+    yCoordinate = np.arange(meta['maxY'], meta['minY'], -meta['pixelSize'])
+    ygrid[:] = yCoordinate
 
-  ### Fill in coordinates
-  xCoordinate = np.arange(meta['minX'], meta['maxX'], meta['pixelSize'])
-  xgrid[:] = xCoordinate
-  yCoordinate = np.arange(meta['maxY'], meta['minY'], -meta['pixelSize'])
-  ygrid[:] = yCoordinate
-
-  dataset.close()
+    dataset.close()
 
 
 def extractNetcdfTime(ncFile, csvFile):
-
-  outF = open(csvFile, 'w')
-  timeSeries = nc.Dataset(ncFile, 'r')
-  timeRef = timeSeries.variables['time'].getncattr('units')[14:]
-  timeRef = datetime.strptime(timeRef, '%Y-%m-%d %H:%M:%S')
-  time = timeSeries.variables['time'][:].tolist()
-  for t in time:
-    timestamp = timeRef + timedelta(seconds=t)
-    outF.write('%s\n' % timestamp.isoformat())
-  outF.close()
+    outF = open(csvFile, 'w')
+    timeSeries = nc.Dataset(ncFile, 'r')
+    timeRef = timeSeries.variables['time'].getncattr('units')[14:]
+    timeRef = datetime.strptime(timeRef, '%Y-%m-%d %H:%M:%S')
+    time = timeSeries.variables['time'][:].tolist()
+    for t in time:
+        timestamp = timeRef + timedelta(seconds=t)
+        outF.write('%s\n' % timestamp.isoformat())
+    outF.close()
 
 
 def nc2meta(ncFile):
+    dataset = nc.Dataset(ncFile, 'r')
 
-  dataset = nc.Dataset(ncFile, 'r')
+    meta = {}
 
-  meta = {}
+    ### Global attributes
+    meta['conventions'] = dataset.Conventions
+    meta['institution'] = dataset.institution
+    meta['title'] = dataset.title
+    meta['source'] = dataset.source
+    meta['comment'] = dataset.comment
+    meta['reference'] = dataset.reference
+    meta['history'] = dataset.history
 
-  ### Global attributes
-  meta['conventions'] = dataset.Conventions
-  meta['institution'] = dataset.institution
-  meta['title'] = dataset.title
-  meta['source'] = dataset.source
-  meta['comment'] = dataset.comment
-  meta['reference'] = dataset.reference
-  meta['history'] = dataset.history
+    ### Coordinates
+    xGrid = dataset.variables['xgrid']
+    (meta['cols'],) = xGrid.shape
+    meta['pixelSize'] = xGrid[1] - xGrid[0]
+    meta['minX'] = np.min(xGrid)
+    meta['maxX'] = np.max(xGrid) + meta['pixelSize']
+    yGrid = dataset.variables['ygrid']
+    (meta['rows'],) = yGrid.shape
+    meta['minY'] = np.min(yGrid) - meta['pixelSize']
+    meta['maxY'] = np.max(yGrid)
 
-  ### Coordinates
-  xGrid = dataset.variables['xgrid']
-  (meta['cols'],) = xGrid.shape
-  meta['pixelSize'] = xGrid[1] - xGrid[0]
-  meta['minX'] = np.min(xGrid)
-  meta['maxX'] = np.max(xGrid) + meta['pixelSize']
-  yGrid = dataset.variables['ygrid']
-  (meta['rows'],) = yGrid.shape
-  meta['minY'] = np.min(yGrid) - meta['pixelSize']
-  meta['maxY'] = np.max(yGrid)
+    ### Time reference
+    time = dataset.variables['time']
+    (meta['timeCount'],) = time.shape
+    meta['refTime'] = time.units[14:]
 
-  ### Time reference
-  time = dataset.variables['time']
-  (meta['timeCount'],) = time.shape
-  meta['refTime'] = time.units[14:]
+    ### Map projection: EPSG
+    proj = dataset.variables['Transverse_Mercator']
+    projSpatialRef = osr.SpatialReference()
+    projSpatialRef.ImportFromWkt(proj.crs_wkt)
+    meta['epsg'] = int(projSpatialRef.GetAttrValue('AUTHORITY', 1))
 
-  ### Map projection: EPSG
-  proj = dataset.variables['Transverse_Mercator']
-  projSpatialRef = osr.SpatialReference()
-  projSpatialRef.ImportFromWkt(proj.crs_wkt)
-  meta['epsg'] = int(projSpatialRef.GetAttrValue('AUTHORITY', 1))
+    ### Image metadata
+    image = dataset.variables['image']
+    meta['imgLongName'] = image.long_name
+    meta['imgUnits'] = image.units
+    meta['imgNoData'] = image.fill_value
 
-  ### Image metadata
-  image = dataset.variables['image']
-  meta['imgLongName'] = image.long_name
-  meta['imgUnits'] = image.units
-  meta['imgNoData'] = image.fill_value
+    dataset.close()
 
-  dataset.close()
-
-  return meta
+    return meta
 
 
 def addImage2netcdf(image, ncFile, granule, imgTime):
+    dataset = nc.Dataset(ncFile, 'a')
 
-  dataset = nc.Dataset(ncFile, 'a')
+    ### Updating time
+    time = dataset.variables['time']
+    name = dataset.variables['granule']
+    data = dataset.variables['image']
+    numGranules = time.shape[0]
+    time[numGranules] = nc.date2num(imgTime, units=time.units, calendar=time.calendar)
+    name[numGranules] = nc.stringtochar(np.array(granule, 'S100'))
+    data[numGranules, :, :] = image
 
-  ### Updating time
-  time = dataset.variables['time']
-  name = dataset.variables['granule']
-  data = dataset.variables['image']
-  numGranules = time.shape[0]
-  time[numGranules] = nc.date2num(imgTime, units=time.units,
-    calendar=time.calendar)
-  name[numGranules] = nc.stringtochar(np.array(granule, 'S100'))
-  data[numGranules,:,:] = image
-
-  dataset.close()
+    dataset.close()
 
 
 def filter_change(image, kernelSize, iterations):
+    (cols, rows) = image.shape
+    positiveChange = np.zeros((rows, cols), dtype=np.uint8)
+    negativeChange = np.zeros((rows, cols), dtype=np.uint8)
+    noChange = np.zeros((rows, cols), dtype=np.uint8)
+    for ii in range(int(cols)):
+        for kk in range(int(rows)):
+            if image[ii, kk] == 1:
+                negativeChange[ii, kk] = 1
+            elif image[ii, kk] == 2:
+                noChange = 1
+            elif image[ii, kk] == 3:
+                positiveChange[ii, kk] = 1
+    image = None
+    positiveChange = ndimage.binary_opening(
+        positiveChange, iterations=iterations, structure=np.ones(kernelSize)
+    ).astype(np.uint8)
+    negativeChange = ndimage.binary_opening(
+        negativeChange, iterations=iterations, structure=np.ones(kernelSize)
+    ).astype(np.uint8)
+    change = np.full((rows, cols), 2, dtype=np.uint8)
+    for ii in range(int(cols)):
+        for kk in range(int(rows)):
+            if negativeChange[ii, kk] == 1:
+                change[ii, kk] = 1
+            elif positiveChange[ii, kk] == 1:
+                change[ii, kk] = 3
+    change *= noChange
 
-  (cols, rows) = image.shape
-  positiveChange = np.zeros((rows,cols), dtype=np.uint8)
-  negativeChange = np.zeros((rows,cols), dtype=np.uint8)
-  noChange = np.zeros((rows,cols), dtype=np.uint8)
-  for ii in range(int(cols)):
-    for kk in range(int(rows)):
-      if image[ii,kk] == 1:
-        negativeChange[ii,kk] = 1
-      elif image[ii,kk] == 2:
-        noChange = 1
-      elif image[ii,kk] == 3:
-        positiveChange[ii,kk] = 1
-  image = None
-  positiveChange = ndimage.binary_opening(positiveChange,
-    iterations=iterations, structure=np.ones(kernelSize)).astype(np.uint8)
-  negativeChange = ndimage.binary_opening(negativeChange,
-    iterations=iterations, structure=np.ones(kernelSize)).astype(np.uint8)
-  change = np.full((rows,cols), 2, dtype=np.uint8)
-  for ii in range(int(cols)):
-    for kk in range(int(rows)):
-      if negativeChange[ii,kk] == 1:
-        change[ii,kk] = 1
-      elif positiveChange[ii,kk] == 1:
-        change[ii,kk] = 3
-  change *= noChange
-
-  return change
+    return change
 
 
 def vector_meta(vectorFile):
-
-  vector = ogr.Open(vectorFile)
-  layer = vector.GetLayer()
-  layerDefinition = layer.GetLayerDefn()
-  fieldCount = layerDefinition.GetFieldCount()
-  fields = []
-  for ii in range(fieldCount):
-    field = {}
-    field['name'] = layerDefinition.GetFieldDefn(ii).GetName()
-    field['type'] = layerDefinition.GetFieldDefn(ii).GetType()
-    field['width'] = layerDefinition.GetFieldDefn(ii).GetWidth()
-    field['precision'] = layerDefinition.GetFieldDefn(ii).GetPrecision()
-    fields.append(field)
-  proj = layer.GetSpatialRef()
-  extent = layer.GetExtent()
-  features = []
-  featureCount = layer.GetFeatureCount()
-  for kk in range(featureCount):
-    value = {}
-    feature = layer.GetFeature(kk)
+    vector = ogr.Open(vectorFile)
+    layer = vector.GetLayer()
+    layerDefinition = layer.GetLayerDefn()
+    fieldCount = layerDefinition.GetFieldCount()
+    fields = []
     for ii in range(fieldCount):
-      if fields[ii]['type'] == ogr.OFTInteger:
-        value[fields[ii]['name']] = int(feature.GetField(ii))
-      elif fields[ii]['type'] == ogr.OFTReal:
-        value[fields[ii]['name']] = float(feature.GetField(ii))
-      else:
-        value[fields[ii]['name']] = feature.GetField(ii)
-    value['geometry'] = feature.GetGeometryRef().ExportToWkt()
-    features.append(value)
+        field = {}
+        field['name'] = layerDefinition.GetFieldDefn(ii).GetName()
+        field['type'] = layerDefinition.GetFieldDefn(ii).GetType()
+        field['width'] = layerDefinition.GetFieldDefn(ii).GetWidth()
+        field['precision'] = layerDefinition.GetFieldDefn(ii).GetPrecision()
+        fields.append(field)
+    proj = layer.GetSpatialRef()
+    extent = layer.GetExtent()
+    features = []
+    featureCount = layer.GetFeatureCount()
+    for kk in range(featureCount):
+        value = {}
+        feature = layer.GetFeature(kk)
+        for ii in range(fieldCount):
+            if fields[ii]['type'] == ogr.OFTInteger:
+                value[fields[ii]['name']] = int(feature.GetField(ii))
+            elif fields[ii]['type'] == ogr.OFTReal:
+                value[fields[ii]['name']] = float(feature.GetField(ii))
+            else:
+                value[fields[ii]['name']] = feature.GetField(ii)
+        value['geometry'] = feature.GetGeometryRef().ExportToWkt()
+        features.append(value)
 
-  return (fields, proj, extent, features)
+    return (fields, proj, extent, features)
 
 
 def raster_metadata(input):
+    # Set up shapefile attributes
+    fields = []
+    field = {}
+    values = []
+    field['name'] = 'granule'
+    field['type'] = ogr.OFTString
+    field['width'] = 254
+    fields.append(field)
+    field = {}
+    field['name'] = 'epsg'
+    field['type'] = ogr.OFTInteger
+    fields.append(field)
+    field = {}
+    field['name'] = 'originX'
+    field['type'] = ogr.OFTReal
+    fields.append(field)
+    field = {}
+    field['name'] = 'originY'
+    field['type'] = ogr.OFTReal
+    fields.append(field)
+    field = {}
+    field['name'] = 'pixSize'
+    field['type'] = ogr.OFTReal
+    fields.append(field)
+    field = {}
+    field['name'] = 'cols'
+    field['type'] = ogr.OFTInteger
+    fields.append(field)
+    field = {}
+    field['name'] = 'rows'
+    field['type'] = ogr.OFTInteger
+    fields.append(field)
+    field = {}
+    field['name'] = 'pixel'
+    field['type'] = ogr.OFTString
+    field['width'] = 8
+    fields.append(field)
 
-  # Set up shapefile attributes
-  fields = []
-  field = {}
-  values = []
-  field['name'] = 'granule'
-  field['type'] = ogr.OFTString
-  field['width'] = 254
-  fields.append(field)
-  field = {}
-  field['name'] = 'epsg'
-  field['type'] = ogr.OFTInteger
-  fields.append(field)
-  field = {}
-  field['name'] = 'originX'
-  field['type'] = ogr.OFTReal
-  fields.append(field)
-  field = {}
-  field['name'] = 'originY'
-  field['type'] = ogr.OFTReal
-  fields.append(field)
-  field = {}
-  field['name'] = 'pixSize'
-  field['type'] = ogr.OFTReal
-  fields.append(field)
-  field = {}
-  field['name'] = 'cols'
-  field['type'] = ogr.OFTInteger
-  fields.append(field)
-  field = {}
-  field['name'] = 'rows'
-  field['type'] = ogr.OFTInteger
-  fields.append(field)
-  field = {}
-  field['name'] = 'pixel'
-  field['type'] = ogr.OFTString
-  field['width'] = 8
-  fields.append(field)
+    # Extract other raster image metadata
+    (outSpatialRef, outGt, outShape, outPixel) = raster_meta(input)
+    if outSpatialRef.GetAttrValue('AUTHORITY', 0) == 'EPSG':
+        epsg = int(outSpatialRef.GetAttrValue('AUTHORITY', 1))
 
-  # Extract other raster image metadata
-  (outSpatialRef, outGt, outShape, outPixel) = raster_meta(input)
-  if outSpatialRef.GetAttrValue('AUTHORITY', 0) == 'EPSG':
-    epsg = int(outSpatialRef.GetAttrValue('AUTHORITY', 1))
+    # Add granule name and geometry
+    base = os.path.basename(input)
+    granule = os.path.splitext(base)[0]
+    value = {}
+    value['granule'] = granule
+    value['epsg'] = epsg
+    value['originX'] = outGt[0]
+    value['originY'] = outGt[3]
+    value['pixSize'] = outGt[1]
+    value['cols'] = outShape[1]
+    value['rows'] = outShape[0]
+    value['pixel'] = outPixel
+    values.append(value)
 
-  # Add granule name and geometry
-  base = os.path.basename(input)
-  granule = os.path.splitext(base)[0]
-  value = {}
-  value['granule'] = granule
-  value['epsg'] = epsg
-  value['originX'] = outGt[0]
-  value['originY'] = outGt[3]
-  value['pixSize'] = outGt[1]
-  value['cols'] = outShape[1]
-  value['rows'] = outShape[0]
-  value['pixel'] = outPixel
-  values.append(value)
-
-  return (fields, values, outSpatialRef)
+    return (fields, values, outSpatialRef)
 
 
 def netcdf2boundary_mask(ncFile, geographic):
+    ### Extract metadata
+    meta = nc2meta(ncFile)
+    cols = meta['cols']
+    rows = meta['rows']
+    proj = osr.SpatialReference()
+    proj.ImportFromEPSG(meta['epsg'])
+    geoTrans = (meta['minX'], meta['pixelSize'], 0, meta['maxY'], 0, -meta['pixelSize'])
 
-  ### Extract metadata
-  meta = nc2meta(ncFile)
-  cols = meta['cols']
-  rows = meta['rows']
-  proj = osr.SpatialReference()
-  proj.ImportFromEPSG(meta['epsg'])
-  geoTrans = \
-    (meta['minX'], meta['pixelSize'], 0, meta['maxY'], 0, -meta['pixelSize'])
+    ### Reading time series
+    dataset = nc.Dataset(ncFile, 'r')
+    image = dataset.variables['image'][:]
+    dataset.close()
 
-  ### Reading time series
-  dataset = nc.Dataset(ncFile, 'r')
-  image = dataset.variables['image'][:]
-  dataset.close()
+    ### Save in memory
+    data = image[0, :, :] / image[0, :, :]
+    image = None
+    gdalDriver = gdal.GetDriverByName('Mem')
+    outRaster = gdalDriver.Create('out', rows, cols, 1, gdal.GDT_Byte)
+    outRaster.SetGeoTransform(geoTrans)
+    outRaster.SetProjection(proj.ExportToWkt())
+    outBand = outRaster.GetRasterBand(1)
+    outBand.WriteArray(data)
+    inBand = None
+    data = None
 
-  ### Save in memory
-  data = image[0,:,:]/image[0,:,:]
-  image = None
-  gdalDriver = gdal.GetDriverByName('Mem')
-  outRaster = gdalDriver.Create('out', rows, cols, 1, gdal.GDT_Byte)
-  outRaster.SetGeoTransform(geoTrans)
-  outRaster.SetProjection(proj.ExportToWkt())
-  outBand = outRaster.GetRasterBand(1)
-  outBand.WriteArray(data)
-  inBand = None
-  data = None
+    ### Polygonize the raster image
+    inBand = outRaster.GetRasterBand(1)
+    ogrDriver = ogr.GetDriverByName('Memory')
+    outVector = ogrDriver.CreateDataSource('out')
+    outLayer = outVector.CreateLayer('boundary', srs=proj)
+    fieldDefinition = ogr.FieldDefn('ID', ogr.OFTInteger)
+    outLayer.CreateField(fieldDefinition)
+    gdal.Polygonize(inBand, inBand, outLayer, 0, [], None)
+    outRaster = None
 
-  ### Polygonize the raster image
-  inBand = outRaster.GetRasterBand(1)
-  ogrDriver = ogr.GetDriverByName('Memory')
-  outVector = ogrDriver.CreateDataSource('out')
-  outLayer = outVector.CreateLayer('boundary', srs=proj)
-  fieldDefinition = ogr.FieldDefn('ID', ogr.OFTInteger)
-  outLayer.CreateField(fieldDefinition)
-  gdal.Polygonize(inBand, inBand, outLayer, 0, [], None)
-  outRaster = None
+    ### Extract geometry from layer
+    inSpatialRef = outLayer.GetSpatialRef()
+    multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
+    for outFeature in outLayer:
+        geometry = outFeature.GetGeometryRef()
+        multipolygon.AddGeometry(geometry)
+        outFeature = None
+    outLayer = None
 
-  ### Extract geometry from layer
-  inSpatialRef = outLayer.GetSpatialRef()
-  multipolygon = ogr.Geometry(ogr.wkbMultiPolygon)
-  for outFeature in outLayer:
-    geometry = outFeature.GetGeometryRef()
-    multipolygon.AddGeometry(geometry)
-    outFeature = None
-  outLayer = None
-
-  ### Convert geometry from projected to geographic coordinates (if requested)
-  if geographic == True:
-    (multipolygon, outSpatialRef) = \
-      geometry_proj2geo(multipolygon, inSpatialRef)
-    return (multipolygon, outSpatialRef)
-  else:
-    return (multipolygon, inSpatialRef)
+    ### Convert geometry from projected to geographic coordinates (if requested)
+    if geographic == True:
+        (multipolygon, outSpatialRef) = geometry_proj2geo(multipolygon, inSpatialRef)
+        return (multipolygon, outSpatialRef)
+    else:
+        return (multipolygon, inSpatialRef)
 
 
 def time_series_slice(ncFile, x, y, typeXY):
+    timeSeries = nc.Dataset(ncFile, 'r')
 
-  timeSeries = nc.Dataset(ncFile, 'r')
+    ### Extract information for variables: image, time, granule
+    timeRef = timeSeries.variables['time'].getncattr('units')[14:]
+    timeRef = datetime.strptime(timeRef, '%Y-%m-%d %H:%M:%S')
+    time = timeSeries.variables['time'][:].tolist()
+    timestamp = []
+    for t in time:
+        timestamp.append(timeRef + timedelta(seconds=t))
+    xGrid = timeSeries.variables['xgrid'][:]
+    yGrid = timeSeries.variables['ygrid'][:]
+    granules = timeSeries.variables['granule']
+    granule = nc.chartostring(granules[:])
+    data = timeSeries.variables['image']
+    # numGranules = len(time)
 
-  ### Extract information for variables: image, time, granule
-  timeRef = timeSeries.variables['time'].getncattr('units')[14:]
-  timeRef = datetime.strptime(timeRef, '%Y-%m-%d %H:%M:%S')
-  time = timeSeries.variables['time'][:].tolist()
-  timestamp = []
-  for t in time:
-    timestamp.append(timeRef + timedelta(seconds=t))
-  xGrid = timeSeries.variables['xgrid'][:]
-  yGrid = timeSeries.variables['ygrid'][:]
-  granules = timeSeries.variables['granule']
-  granule = nc.chartostring(granules[:])
-  data = timeSeries.variables['image']
-  # numGranules = len(time)
-
-  ### Define geo transformation and map proejction
-  # originX = xGrid[0]
-  # originY = yGrid[0]
-  pixelSize = xGrid[1] - xGrid[0]
-  # gt = (originX, pixelSize, 0, originY, 0, -pixelSize)
-  var = timeSeries.variables.keys()
-  if 'Transverse_Mercator' in var:
-    wkt = timeSeries.variables['Transverse_Mercator'].getncattr('crs_wkt')
-  else:
-    raise GeometryError('Could not find map projection information!')
-
-  ### Work out line/sample from various input types
-  if typeXY == 'pixel':
-    sample = x
-    line = y
-  elif typeXY == 'latlon':
-    inProj = osr.SpatialReference()
-    inProj.ImportFromEPSG(4326)
-    outProj = osr.SpatialReference()
-    outProj.ImportFromWkt(wkt)
-    transform = osr.CoordinateTransformation(inProj, outProj)
-    coord = ogr.Geometry(ogr.wkbPoint)
-    coord.AddPoint(x,y)
-    coord.Transform(transform)
-    coordX = np.rint(coord.GetX()/pixelSize)*pixelSize
-    coordY = np.rint(coord.GetY()/pixelSize)*pixelSize
-    sample = xGrid.tolist().index(coordX)
-    line = yGrid.tolist().index(coordY)
-  elif typeXY == 'mapXY':
-    sample = xGrid.tolist().index(x)
-    line = yGrid.tolist().index(y)
-  value = data[:,sample,line]
-
-  ### Work on time series
-  ## Fill in gaps by interpolation
-  startDate = timestamp[0].date()
-  stopDate = timestamp[len(timestamp)-1].date()
-  refDates = np.arange(startDate, stopDate + timedelta(days=12), 12).tolist()
-  datestamp = []
-  for t in time:
-    datestamp.append((timeRef + timedelta(seconds=t)).date())
-  missingDates = list(set(refDates) - set(datestamp))
-  f = interp1d(time, value)
-  missingTime = []
-  for missingDate in missingDates:
-    missingTime.append((missingDate - timeRef.date()).total_seconds())
-  missingValues = f(missingTime)
-  allValues = []
-  refType = []
-  for ii in range(len(refDates)):
-    if refDates[ii] in missingDates:
-      index = missingDates.index(refDates[ii])
-      allValues.append(missingValues[index])
-      refType.append('interpolated')
+    ### Define geo transformation and map proejction
+    # originX = xGrid[0]
+    # originY = yGrid[0]
+    pixelSize = xGrid[1] - xGrid[0]
+    # gt = (originX, pixelSize, 0, originY, 0, -pixelSize)
+    var = timeSeries.variables.keys()
+    if 'Transverse_Mercator' in var:
+        wkt = timeSeries.variables['Transverse_Mercator'].getncattr('crs_wkt')
     else:
-      index = datestamp.index(refDates[ii])
-      allValues.append(value[index])
-      refType.append('acquired')
-  allValues = np.asarray(allValues)
+        raise GeometryError('Could not find map projection information!')
 
-  ## Smoothing the time line with localized regression (LOESS)
-  lowess = sm.nonparametric.lowess
-  smooth = lowess(allValues, np.arange(len(allValues)), frac=0.08, it=0)[:,1]
+    ### Work out line/sample from various input types
+    if typeXY == 'pixel':
+        sample = x
+        line = y
+    elif typeXY == 'latlon':
+        inProj = osr.SpatialReference()
+        inProj.ImportFromEPSG(4326)
+        outProj = osr.SpatialReference()
+        outProj.ImportFromWkt(wkt)
+        transform = osr.CoordinateTransformation(inProj, outProj)
+        coord = ogr.Geometry(ogr.wkbPoint)
+        coord.AddPoint(x, y)
+        coord.Transform(transform)
+        coordX = np.rint(coord.GetX() / pixelSize) * pixelSize
+        coordY = np.rint(coord.GetY() / pixelSize) * pixelSize
+        sample = xGrid.tolist().index(coordX)
+        line = yGrid.tolist().index(coordY)
+    elif typeXY == 'mapXY':
+        sample = xGrid.tolist().index(x)
+        line = yGrid.tolist().index(y)
+    value = data[:, sample, line]
 
-  sd = seasonal_decompose(x=smooth, model='additive', freq=4)
+    ### Work on time series
+    ## Fill in gaps by interpolation
+    startDate = timestamp[0].date()
+    stopDate = timestamp[len(timestamp) - 1].date()
+    refDates = np.arange(startDate, stopDate + timedelta(days=12), 12).tolist()
+    datestamp = []
+    for t in time:
+        datestamp.append((timeRef + timedelta(seconds=t)).date())
+    missingDates = list(set(refDates) - set(datestamp))
+    f = interp1d(time, value)
+    missingTime = []
+    for missingDate in missingDates:
+        missingTime.append((missingDate - timeRef.date()).total_seconds())
+    missingValues = f(missingTime)
+    allValues = []
+    refType = []
+    for ii in range(len(refDates)):
+        if refDates[ii] in missingDates:
+            index = missingDates.index(refDates[ii])
+            allValues.append(missingValues[index])
+            refType.append('interpolated')
+        else:
+            index = datestamp.index(refDates[ii])
+            allValues.append(value[index])
+            refType.append('acquired')
+    allValues = np.asarray(allValues)
 
-  return (granule, refDates, refType, smooth, sd)
+    ## Smoothing the time line with localized regression (LOESS)
+    lowess = sm.nonparametric.lowess
+    smooth = lowess(allValues, np.arange(len(allValues)), frac=0.08, it=0)[:, 1]
+
+    sd = seasonal_decompose(x=smooth, model='additive', freq=4)
+
+    return (granule, refDates, refType, smooth, sd)

--- a/src/hyp3lib/asf_time_series.py
+++ b/src/hyp3lib/asf_time_series.py
@@ -12,6 +12,7 @@ from statsmodels.tsa.seasonal import seasonal_decompose
 from hyp3lib import GeometryError
 from hyp3lib.asf_geometry import geometry_proj2geo, raster_meta
 
+
 tolerance = 0.00005
 
 

--- a/src/hyp3lib/aws.py
+++ b/src/hyp3lib/aws.py
@@ -7,6 +7,7 @@ from typing import Union
 
 import boto3
 
+
 S3_CLIENT = boto3.client('s3')
 
 

--- a/src/hyp3lib/aws.py
+++ b/src/hyp3lib/aws.py
@@ -22,14 +22,7 @@ def get_tag_set(file_name: str) -> dict:
     else:
         file_type = 'product'
 
-    tag_set = {
-        'TagSet': [
-            {
-                'Key': 'file_type',
-                'Value': file_type
-            }
-        ]
-    }
+    tag_set = {'TagSet': [{'Key': 'file_type', 'Value': file_type}]}
     return tag_set
 
 

--- a/src/hyp3lib/byteSigmaScale.py
+++ b/src/hyp3lib/byteSigmaScale.py
@@ -1,9 +1,11 @@
 """Convert a floating point tiff into a byte tiff using 2-sigma scaling."""
-import os
 import argparse
-from hyp3lib import saa_func_lib as saa
+import os
+
 import numpy as np
 from osgeo import gdal
+
+from hyp3lib import saa_func_lib as saa
 
 
 def get2sigmacutoffs(fi):

--- a/src/hyp3lib/byteSigmaScale.py
+++ b/src/hyp3lib/byteSigmaScale.py
@@ -35,7 +35,7 @@ def byteSigmaScale(infile, outfile):
     (x, y, trans, proj, data) = saa.read_gdal_file(saa.open_gdal_file(outfile))
     mask2 = (data > 0).astype(bool)
     mask3 = mask ^ mask2
-    data[mask3 == True] = 1
+    data[mask3 is True] = 1
     saa.write_gdal_file_byte(outfile, trans, proj, data, nodata=0)
 
 

--- a/src/hyp3lib/byteSigmaScale.py
+++ b/src/hyp3lib/byteSigmaScale.py
@@ -7,32 +7,34 @@ from osgeo import gdal
 
 
 def get2sigmacutoffs(fi):
-    (x,y,trans,proj,data) = saa.read_gdal_file(saa.open_gdal_file(fi))
+    (x, y, trans, proj, data) = saa.read_gdal_file(saa.open_gdal_file(fi))
     data = data.astype(float)
-    data[data==0]=np.nan
-    top = np.nanpercentile(data,99)
-    data[data>top]=top
+    data[data == 0] = np.nan
+    top = np.nanpercentile(data, 99)
+    data[data > top] = top
     stddev = np.nanstd(data)
     mean = np.nanmean(data)
-    lo = mean - 2*stddev
-    hi = mean + 2*stddev
-    return lo,hi
+    lo = mean - 2 * stddev
+    hi = mean + 2 * stddev
+    return lo, hi
 
 
-def byteSigmaScale(infile,outfile):
-    lo,hi = get2sigmacutoffs(infile)
-    print("2-sigma cutoffs are {} {}".format(lo, hi))
-    gdal.Translate(outfile,infile,outputType=gdal.GDT_Byte,scaleParams=[[lo,hi,1,255]],resampleAlg="average",noData="0")
+def byteSigmaScale(infile, outfile):
+    lo, hi = get2sigmacutoffs(infile)
+    print('2-sigma cutoffs are {} {}'.format(lo, hi))
+    gdal.Translate(
+        outfile, infile, outputType=gdal.GDT_Byte, scaleParams=[[lo, hi, 1, 255]], resampleAlg='average', noData='0'
+    )
 
     # For some reason, I'm still getting zeros in my byte images eventhough I'm using 1,255 scaling!
     # The following in an attempt to fix that!
-    (x,y,trans,proj,data) = saa.read_gdal_file(saa.open_gdal_file(infile))
-    mask = (data>0).astype(bool)
-    (x,y,trans,proj,data) = saa.read_gdal_file(saa.open_gdal_file(outfile))
-    mask2 = (data>0).astype(bool)
+    (x, y, trans, proj, data) = saa.read_gdal_file(saa.open_gdal_file(infile))
+    mask = (data > 0).astype(bool)
+    (x, y, trans, proj, data) = saa.read_gdal_file(saa.open_gdal_file(outfile))
+    mask2 = (data > 0).astype(bool)
     mask3 = mask ^ mask2
-    data[mask3==True] = 1
-    saa.write_gdal_file_byte(outfile,trans,proj,data,nodata=0)
+    data[mask3 == True] = 1
+    saa.write_gdal_file_byte(outfile, trans, proj, data, nodata=0)
 
 
 def main():
@@ -42,11 +44,11 @@ def main():
         prog=os.path.basename(__file__),
         description=__doc__,
     )
-    parser.add_argument("infile", help="Geotiff file to convert")
-    parser.add_argument("outfile", help="Name of output file to create")
+    parser.add_argument('infile', help='Geotiff file to convert')
+    parser.add_argument('outfile', help='Name of output file to create')
     args = parser.parse_args()
     byteSigmaScale(args.infile, args.outfile)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/src/hyp3lib/createAmp.py
+++ b/src/hyp3lib/createAmp.py
@@ -1,8 +1,10 @@
 """Convert Geotiff Power to Amplitude"""
-from hyp3lib import saa_func_lib as saa
-import numpy as np
 import argparse
 import os
+
+import numpy as np
+
+from hyp3lib import saa_func_lib as saa
 
 
 def createAmp(fi, nodata=None):

--- a/src/hyp3lib/createAmp.py
+++ b/src/hyp3lib/createAmp.py
@@ -5,11 +5,11 @@ import argparse
 import os
 
 
-def createAmp(fi,nodata=None):
-    (x,y,trans,proj,data) = saa.read_gdal_file(saa.open_gdal_file(fi))
+def createAmp(fi, nodata=None):
+    (x, y, trans, proj, data) = saa.read_gdal_file(saa.open_gdal_file(fi))
     ampdata = np.sqrt(data)
-    outfile = fi.replace('.tif','_amp.tif')
-    saa.write_gdal_file_float(outfile,trans,proj,ampdata,nodata=nodata)
+    outfile = fi.replace('.tif', '_amp.tif')
+    saa.write_gdal_file_float(outfile, trans, proj, ampdata, nodata=nodata)
     return outfile
 
 
@@ -20,8 +20,8 @@ def main():
         prog=os.path.basename(__file__),
         description=__doc__,
     )
-    parser.add_argument("infile", nargs="+", help="Input tif filename(s)")
-    parser.add_argument("-n", "--nodata", type=float, help="Set nodata value")
+    parser.add_argument('infile', nargs='+', help='Input tif filename(s)')
+    parser.add_argument('-n', '--nodata', type=float, help='Set nodata value')
     args = parser.parse_args()
 
     infiles = args.infile
@@ -29,5 +29,5 @@ def main():
         createAmp(fi, args.nodata)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/src/hyp3lib/execute.py
+++ b/src/hyp3lib/execute.py
@@ -9,8 +9,9 @@ from typing import Optional, TextIO, Union
 from hyp3lib import ExecuteError
 
 
-def execute(cmd: str, expected: Optional[Union[str, Path]] = None, logfile: Optional[TextIO] = None,
-            uselogging: bool = False) -> str:
+def execute(
+    cmd: str, expected: Optional[Union[str, Path]] = None, logfile: Optional[TextIO] = None, uselogging: bool = False
+) -> str:
     """
     Run a command in a subprocess and perform some post-process verification of
     the command's execution
@@ -46,7 +47,7 @@ def execute(cmd: str, expected: Optional[Union[str, Path]] = None, logfile: Opti
             else:
                 print('Proc: ' + line)
             if logfile is not None:
-                logfile.write("%s\n" % line)
+                logfile.write('%s\n' % line)
 
     if uselogging:
         logging.info('Finished: ' + cmd)
@@ -93,6 +94,6 @@ def execute(cmd: str, expected: Optional[Union[str, Path]] = None, logfile: Opti
                 logging.info('Expected output file not found: ' + expected)
             else:
                 print('Expected output file not found: ' + expected)
-            raise ExecuteError("Expected output file not found: " + expected)
+            raise ExecuteError('Expected output file not found: ' + expected)
 
     return output

--- a/src/hyp3lib/fetch.py
+++ b/src/hyp3lib/fetch.py
@@ -13,8 +13,9 @@ from urllib3.util.retry import Retry
 EARTHDATA_LOGIN_DOMAIN = 'urs.earthdata.nasa.gov'
 
 
-def write_credentials_to_netrc_file(username: str, password: str,
-                                    domain: str = EARTHDATA_LOGIN_DOMAIN, append: bool = False):
+def write_credentials_to_netrc_file(
+    username: str, password: str, domain: str = EARTHDATA_LOGIN_DOMAIN, append: bool = False
+):
     """Write credentials to .netrc file"""
     netrc_file = Path.home() / '.netrc'
     if netrc_file.exists() and not append:
@@ -36,8 +37,15 @@ def _get_download_path(url: str, content_disposition: str = None, directory: Uni
     return Path(directory) / filename
 
 
-def download_file(url: str, directory: Union[Path, str] = '.', chunk_size=None, retries=2, backoff_factor=1,
-                  auth: Optional[Tuple[str, str]] = None, token: Optional[str] = None) -> str:
+def download_file(
+    url: str,
+    directory: Union[Path, str] = '.',
+    chunk_size=None,
+    retries=2,
+    backoff_factor=1,
+    auth: Optional[Tuple[str, str]] = None,
+    token: Optional[str] = None,
+) -> str:
     """Download a file
 
     Args:
@@ -70,7 +78,7 @@ def download_file(url: str, directory: Union[Path, str] = '.', chunk_size=None, 
     with session.get(url, stream=True) as s:
         download_path = _get_download_path(s.url, s.headers.get('content-disposition'), directory)
         s.raise_for_status()
-        with open(download_path, "wb") as f:
+        with open(download_path, 'wb') as f:
             for chunk in s.iter_content(chunk_size=chunk_size):
                 if chunk:
                     f.write(chunk)

--- a/src/hyp3lib/fetch.py
+++ b/src/hyp3lib/fetch.py
@@ -10,6 +10,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+
 EARTHDATA_LOGIN_DOMAIN = 'urs.earthdata.nasa.gov'
 
 

--- a/src/hyp3lib/getParameter.py
+++ b/src/hyp3lib/getParameter.py
@@ -6,20 +6,20 @@ def getParameter(parFile, parameter, uselogging=False):
     """Read a value from a par file"""
     value = None
     try:
-        with open(parFile, "r") as myfile:
+        with open(parFile, 'r') as myfile:
             parameter = parameter.lower()
             for line in myfile:
                 if parameter in line.lower():
-                    t = re.split(":", line)
+                    t = re.split(':', line)
                     value = t[1].strip()
     except IOError:
         if uselogging:
-            logging.error("Unable to find file {}".format(parFile))
-        raise Exception("ERROR: Unable to find file {}".format(parFile))
+            logging.error('Unable to find file {}'.format(parFile))
+        raise Exception('ERROR: Unable to find file {}'.format(parFile))
 
     if value is None:
         if uselogging:
-            logging.error("Unable to find parameter {} in file {}".format(parameter, parFile))
-        raise Exception("ERROR: Unable to find parameter {} in file {}".format(parameter, parFile))
+            logging.error('Unable to find parameter {} in file {}'.format(parameter, parFile))
+        raise Exception('ERROR: Unable to find parameter {} in file {}'.format(parameter, parFile))
 
     return value

--- a/src/hyp3lib/get_orb.py
+++ b/src/hyp3lib/get_orb.py
@@ -70,8 +70,9 @@ def _get_asf_orbit_url(orbit_type, platform, timestamp):
     response = session.get(search_url)
     response.raise_for_status()
     tree = html.fromstring(response.content)
-    file_list = [file for file in tree.xpath('//a[@href]//@href')
-                 if file.startswith(platform) and file.endswith('.EOF')]
+    file_list = [
+        file for file in tree.xpath('//a[@href]//@href') if file.startswith(platform) and file.endswith('.EOF')
+    ]
 
     d1 = 0
     best = None
@@ -99,9 +100,9 @@ def _get_esa_orbit_url(orbit_type: str, platform: str, start_time: datetime, end
     date_format = '%Y-%m-%dT%H:%M:%SZ'
     params = {
         '$filter': f"Collection/Name eq 'SENTINEL-1' and "
-                   f"startswith(Name, '{platform}_OPER_{orbit_type}_OPOD_') and "
-                   f"ContentDate/Start lt {start_time.strftime(date_format)} and "
-                   f"ContentDate/End gt {end_time.strftime(date_format)}",
+        f"startswith(Name, '{platform}_OPER_{orbit_type}_OPOD_') and "
+        f'ContentDate/Start lt {start_time.strftime(date_format)} and '
+        f'ContentDate/End gt {end_time.strftime(date_format)}',
         '$orderby': 'Name desc',
         '$top': 1,
     }
@@ -116,6 +117,7 @@ def _get_esa_orbit_url(orbit_type: str, platform: str, start_time: datetime, end
         orbit_url = f'https://zipper.dataspace.copernicus.eu/download/{product_id}'
 
     return orbit_url
+
 
 def get_orbit_url(granule: str, orbit_type: str = 'AUX_POEORB', provider: str = 'ESA'):
     """Get the URL of a Sentinel-1 orbit file from a provider
@@ -144,8 +146,11 @@ def get_orbit_url(granule: str, orbit_type: str = 'AUX_POEORB', provider: str = 
 
 
 def downloadSentinelOrbitFile(
-        granule: str, directory: str = '', providers=('ESA', 'ASF'), orbit_types=('AUX_POEORB', 'AUX_RESORB'),
-        esa_credentials: Optional[Tuple[str, str]] = None,
+    granule: str,
+    directory: str = '',
+    providers=('ESA', 'ASF'),
+    orbit_types=('AUX_POEORB', 'AUX_RESORB'),
+    esa_credentials: Optional[Tuple[str, str]] = None,
 ):
     """Download a Sentinel-1 Orbit file
 
@@ -191,13 +196,24 @@ def main():
         description=__doc__,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument('safe_files', help='Sentinel-1 SAFE file name(s)', nargs="*")
-    parser.add_argument('-p', '--provider', nargs='*', default=['ESA', 'ASF'], choices=['ESA', 'ASF'],
-                        help="Name(s) of the orbit file providers' organization, in order of preference")
-    parser.add_argument('-t', '--orbit-types', nargs='*', default=['AUX_POEORB', 'AUX_RESORB'],
-                        choices=['MPL_ORBPRE', 'AUX_POEORB', 'AUX_PREORB', 'AUX_RESORB', 'AUX_RESATT'],
-                        help="Name(s) of the orbit file providers' organization, in order of preference. "
-                             "See https://qc.sentinel1.eo.esa.int/")
+    parser.add_argument('safe_files', help='Sentinel-1 SAFE file name(s)', nargs='*')
+    parser.add_argument(
+        '-p',
+        '--provider',
+        nargs='*',
+        default=['ESA', 'ASF'],
+        choices=['ESA', 'ASF'],
+        help="Name(s) of the orbit file providers' organization, in order of preference",
+    )
+    parser.add_argument(
+        '-t',
+        '--orbit-types',
+        nargs='*',
+        default=['AUX_POEORB', 'AUX_RESORB'],
+        choices=['MPL_ORBPRE', 'AUX_POEORB', 'AUX_PREORB', 'AUX_RESORB', 'AUX_RESATT'],
+        help="Name(s) of the orbit file providers' organization, in order of preference. "
+        'See https://qc.sentinel1.eo.esa.int/',
+    )
     parser.add_argument('-d', '--directory', default=os.getcwd(), help='Download files to this directory')
     args = parser.parse_args()
 
@@ -212,10 +228,10 @@ def main():
             orbit_file, provided_by = downloadSentinelOrbitFile(
                 safe, directory=args.directory, providers=args.provider, orbit_types=args.orbit_types
             )
-            logging.info("Downloaded orbit file {} from {}".format(orbit_file, provided_by))
+            logging.info('Downloaded orbit file {} from {}'.format(orbit_file, provided_by))
         except OrbitDownloadError as e:
             logging.warning(f'WARNING: unable to download orbit file for {safe}\n    {e}')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/src/hyp3lib/get_orb.py
+++ b/src/hyp3lib/get_orb.py
@@ -17,6 +17,7 @@ from urllib3.util.retry import Retry
 from hyp3lib import OrbitDownloadError
 from hyp3lib.fetch import download_file
 
+
 ESA_CREATE_TOKEN_URL = 'https://identity.dataspace.copernicus.eu/auth/realms/CDSE/protocol/openid-connect/token'
 ESA_DELETE_TOKEN_URL = 'https://identity.dataspace.copernicus.eu/auth/realms/CDSE/account/sessions'
 

--- a/src/hyp3lib/image.py
+++ b/src/hyp3lib/image.py
@@ -1,8 +1,9 @@
 """Tools for working with images"""
 
-from PIL import Image
-from typing import Tuple
 from pathlib import Path
+from typing import Tuple
+
+from PIL import Image
 
 
 def create_thumbnail(input_image: Path, size: Tuple[int, int] = (100, 100), output_dir: Path = None) -> Path:

--- a/src/hyp3lib/makeAsfBrowse.py
+++ b/src/hyp3lib/makeAsfBrowse.py
@@ -28,8 +28,9 @@ def makeAsfBrowse(geotiff: str, base_name: str, use_nn=False, width: int = 2048)
     tiff = None  # How to close with gdal
 
     if tiff_width < width:
-        logging.warning(f'Requested image dimension of {width} exceeds GeoTIFF width {tiff_width}.'
-                        f' Using GeoTIFF width')
+        logging.warning(
+            f'Requested image dimension of {width} exceeds GeoTIFF width {tiff_width}.' f' Using GeoTIFF width'
+        )
         browse_width = tiff_width
     else:
         browse_width = width
@@ -50,11 +51,13 @@ def main():
     )
     parser.add_argument('geotiff', help='name of GeoTIFF file to resample')
     parser.add_argument('basename', help='base name of output files')
-    parser.add_argument('-n', '--nearest-neighbor', action='store_true',
-                        help="use GDAL's GRIORA_NearestNeighbour interpolation instead"
-                             " of GRIORA_Cubic to resample the GeoTIFF")
-    parser.add_argument('-w', '--width', default=2048,
-                        help='browse image width')
+    parser.add_argument(
+        '-n',
+        '--nearest-neighbor',
+        action='store_true',
+        help="use GDAL's GRIORA_NearestNeighbour interpolation instead" ' of GRIORA_Cubic to resample the GeoTIFF',
+    )
+    parser.add_argument('-w', '--width', default=2048, help='browse image width')
     args = parser.parse_args()
 
     out = logging.StreamHandler(stream=sys.stdout)
@@ -68,9 +71,7 @@ def main():
     if os.path.splitext(args.basename)[-1]:
         parser.error(f'Output file {args.basename} has an extension!')
 
-    makeAsfBrowse(
-        args.geotiff, args.basename, use_nn=args.nearest_neighbor, width=args.width
-    )
+    makeAsfBrowse(args.geotiff, args.basename, use_nn=args.nearest_neighbor, width=args.width)
 
 
 if __name__ == '__main__':

--- a/src/hyp3lib/par_s1_slc_single.py
+++ b/src/hyp3lib/par_s1_slc_single.py
@@ -10,7 +10,7 @@ from hyp3lib.get_orb import downloadSentinelOrbitFile
 
 def make_cmd(swath, acquisition_date, out_dir, pol=None):
     """Assemble the par_S1_SLC gamma commands
-    
+
     Args:
         swath: Swath to process
         acquisition_date: The acquisition date of the SLC imagery
@@ -27,10 +27,12 @@ def make_cmd(swath, acquisition_date, out_dir, pol=None):
         n = glob.glob(f'annotation/s1*-iw{swath}*{pol}*')[0]
         o = glob.glob(f'annotation/calibration/calibration-s1*-iw{swath}*{pol}*')[0]
         p = glob.glob(f'annotation/calibration/noise-s1*-iw{swath}*{pol}*')[0]
-    
-    cmd = f'par_S1_SLC {m} {n} {o} {p} {out_dir}/{acquisition_date}_00{swath}.slc.par ' \
-          f'{out_dir}/{acquisition_date}_00{swath}.slc {out_dir}/{acquisition_date}_00{swath}.tops_par'
-    
+
+    cmd = (
+        f'par_S1_SLC {m} {n} {o} {p} {out_dir}/{acquisition_date}_00{swath}.slc.par '
+        f'{out_dir}/{acquisition_date}_00{swath}.slc {out_dir}/{acquisition_date}_00{swath}.tops_par'
+    )
+
     return cmd
 
 
@@ -91,5 +93,5 @@ def par_s1_slc_single(safe_dir, pol='vv', orbit_file=None):
 
     # Make a raster version of swath 3
     width = getParameter(f'{acquisition_date}_003.slc.par', 'range_samples')
-    execute(f"rasSLC {acquisition_date}_003.slc {width} 1 0 50 10")
+    execute(f'rasSLC {acquisition_date}_003.slc {width} 1 0 50 10')
     os.chdir(wrk)

--- a/src/hyp3lib/raster_boundary2shape.py
+++ b/src/hyp3lib/raster_boundary2shape.py
@@ -5,7 +5,7 @@ import os
 
 from scipy import ndimage
 
-from hyp3lib.asf_geometry import geotiff2boundary_mask, data_geometry2shape
+from hyp3lib.asf_geometry import data_geometry2shape, geotiff2boundary_mask
 from hyp3lib.asf_time_series import raster_metadata
 
 

--- a/src/hyp3lib/raster_boundary2shape.py
+++ b/src/hyp3lib/raster_boundary2shape.py
@@ -9,42 +9,40 @@ from hyp3lib.asf_geometry import geotiff2boundary_mask, data_geometry2shape
 from hyp3lib.asf_time_series import raster_metadata
 
 
-def raster_boundary2shape(inFile, threshold, outShapeFile, use_closing=True, fill_holes = False,
-                          pixel_shift=False):
+def raster_boundary2shape(inFile, threshold, outShapeFile, use_closing=True, fill_holes=False, pixel_shift=False):
     # Extract raster image metadata
     print('Extracting raster information ...')
     (fields, values, spatialRef) = raster_metadata(inFile)
 
-    print("Initial origin {x},{y}".format(x=values[0]['originX'],y=values[0]['originY']))
+    print('Initial origin {x},{y}'.format(x=values[0]['originX'], y=values[0]['originY']))
 
     if spatialRef.GetAttrValue('AUTHORITY', 0) == 'EPSG':
         epsg = int(spatialRef.GetAttrValue('AUTHORITY', 1))
     # Generate GeoTIFF boundary geometry
     print('Extracting boundary geometry ...')
-    (data, colFirst, rowFirst, geoTrans, proj) = \
-        geotiff2boundary_mask(inFile, epsg, threshold,use_closing=use_closing)
+    (data, colFirst, rowFirst, geoTrans, proj) = geotiff2boundary_mask(inFile, epsg, threshold, use_closing=use_closing)
     (rows, cols) = data.shape
 
-    print("After geotiff2boundary_mask origin {x},{y}".format(x=geoTrans[0],y=geoTrans[3]))
- 
+    print('After geotiff2boundary_mask origin {x},{y}'.format(x=geoTrans[0], y=geoTrans[3]))
+
     if fill_holes:
-      data = ndimage.binary_fill_holes(data).astype(bool)
+        data = ndimage.binary_fill_holes(data).astype(bool)
 
-#    if pixel_shift:
-      if values[0]['pixel']:
-          minx = geoTrans[0]
-          maxy = geoTrans[3]
-          # maxx = geoTrans[0] + cols*geoTrans[1]
-          # miny = geoTrans[3] + rows*geoTrans[5]
+        #    if pixel_shift:
+        if values[0]['pixel']:
+            minx = geoTrans[0]
+            maxy = geoTrans[3]
+            # maxx = geoTrans[0] + cols*geoTrans[1]
+            # miny = geoTrans[3] + rows*geoTrans[5]
 
-          # compute the pixel-aligned bounding box (larger than the feature's bbox)
-          left = minx -  (geoTrans[1]/2)
-          top = maxy - (geoTrans[5]/2)
+            # compute the pixel-aligned bounding box (larger than the feature's bbox)
+            left = minx - (geoTrans[1] / 2)
+            top = maxy - (geoTrans[5] / 2)
 
-          values[0]['originX'] = left
-          values[0]['originY'] = top 
+            values[0]['originX'] = left
+            values[0]['originY'] = top
 
-    print("After pixel_shift origin {x},{y}".format(x=values[0]['originX'],y=values[0]['originY']))
+    print('After pixel_shift origin {x},{y}'.format(x=values[0]['originX'], y=values[0]['originY']))
 
     values[0]['rows'] = rows
     values[0]['cols'] = cols
@@ -61,29 +59,28 @@ def main():
         prog=os.path.basename(__file__),
         description=__doc__,
     )
-    parser.add_argument('input', metavar='<geotiff file>',
-             help='name of the GeoTIFF file')
-    parser.add_argument('-threshold', metavar='<code>', action='store',
-             default=None, help='threshold value what is considered blackfill')
-    parser.add_argument('shape', metavar='<shape file>',help='name of the shapefile')
+    parser.add_argument('input', metavar='<geotiff file>', help='name of the GeoTIFF file')
+    parser.add_argument(
+        '-threshold',
+        metavar='<code>',
+        action='store',
+        default=None,
+        help='threshold value what is considered blackfill',
+    )
+    parser.add_argument('shape', metavar='<shape file>', help='name of the shapefile')
 
-    parser.add_argument('--fill_holes', default=False, action="store_true", help='Turn on hole filling')
+    parser.add_argument('--fill_holes', default=False, action='store_true', help='Turn on hole filling')
 
-    parser.add_argument('--pixel_shift', default=False,
-            action="store_true", help='apply pixel shift')
+    parser.add_argument('--pixel_shift', default=False, action='store_true', help='apply pixel shift')
 
-    parser.add_argument('--no_closing',
-             default=True,action='store_false',
-             help='Switch to turn off closing operation')
+    parser.add_argument('--no_closing', default=True, action='store_false', help='Switch to turn off closing operation')
 
     args = parser.parse_args()
 
     if not os.path.exists(args.input):
         parser.error(f'GeoTIFF file {args.input} does not exist!')
 
-    raster_boundary2shape(
-        args.input, args.threshold, args.shape, args.no_closing, args.fill_holes, args.pixel_shift
-    )
+    raster_boundary2shape(args.input, args.threshold, args.shape, args.no_closing, args.fill_holes, args.pixel_shift)
 
 
 if __name__ == '__main__':

--- a/src/hyp3lib/resample_geotiff.py
+++ b/src/hyp3lib/resample_geotiff.py
@@ -171,10 +171,10 @@ def resample_geotiff(geotiff, width, outFormat, outFile, use_nn=False):
         if path != '':
             os.chdir(path)
         zipFile = os.path.basename(outFile.replace(orgExt, '.kmz'))
-        zip = zipfile.ZipFile(zipFile, 'w', zipfile.ZIP_DEFLATED)
-        zip.write(os.path.basename(kmlFile))
-        zip.write(os.path.basename(pngFile))
-        zip.close()
+        zipobj = zipfile.ZipFile(zipFile, 'w', zipfile.ZIP_DEFLATED)
+        zipobj.write(os.path.basename(kmlFile))
+        zipobj.write(os.path.basename(pngFile))
+        zipobj.close()
         os.chdir(back)
 
         # Clean up - remove temporary GeoTIFF, KML and PNG

--- a/src/hyp3lib/resample_geotiff.py
+++ b/src/hyp3lib/resample_geotiff.py
@@ -11,160 +11,187 @@ from osgeo import gdal
 from osgeo.gdalconst import GRIORA_Cubic, GRIORA_NearestNeighbour
 
 
-def resample_geotiff(geotiff, width, outFormat, outFile, use_nn = False):
-
-  # Check output format
-  formats = ['GEOTIFF', 'JPEG', 'JPG', 'PNG', 'KML']
-  if outFormat.upper() not in formats:
-    raise ValueError(f'Unknown output format ({outFormat.upper()})! Accepted formats: {formats}')
-  if use_nn:
-      resampleMethod = GRIORA_NearestNeighbour
-  else:
-      resampleMethod = GRIORA_Cubic
-
-  # Suppress GDAL warnings
-  gdal.UseExceptions()
-  gdal.PushErrorHandler('CPLQuietErrorHandler')
-
-  # Extract information from GeoTIFF
-  raster = gdal.Open(geotiff)
-  bandCount = raster.RasterCount
-  band = raster.GetRasterBand(1)
-  colorTable = band.GetColorTable()
-
-  # Downsample by multiples of pixel size to avoid interpolation issues
-  # (if needed)
-  orgExt = os.path.splitext(outFile)[1]
-  resampleFile = None
-  resampleFile2 = None
-  gt = raster.GetGeoTransform()
-  cols = raster.RasterXSize
-  # rows = raster.RasterYSize
-  scale = cols / float(width)
-  mult = 2 ** (math.floor(math.log(scale,2))-1)
-  
-  if mult > 1:
-    pixelWidth = gt[1] * mult
-    pixelHeight = gt[5] * mult
-    if outFormat.upper() == 'PNG' and bandCount == 3: 
-      tmpExt = ('_resamp{0}.png'.format(os.getpid()))
-      resampleFile = outFile.replace(orgExt, tmpExt)
-      tmpExt2 = ('_resamp2{0}.png'.format(os.getpid()))
-      resampleFile2 = outFile.replace(orgExt, tmpExt2)
-      gdal.Translate(resampleFile,raster,format='PNG',noData='0 0 0')
-      gdal.Translate(resampleFile2,resampleFile, resampleAlg=resampleMethod, format='PNG',
-        xRes=pixelWidth, yRes=pixelHeight, noData="0 0 0")
-      raster = gdal.Open(resampleFile2)
+def resample_geotiff(geotiff, width, outFormat, outFile, use_nn=False):
+    # Check output format
+    formats = ['GEOTIFF', 'JPEG', 'JPG', 'PNG', 'KML']
+    if outFormat.upper() not in formats:
+        raise ValueError(f'Unknown output format ({outFormat.upper()})! Accepted formats: {formats}')
+    if use_nn:
+        resampleMethod = GRIORA_NearestNeighbour
     else:
-      tmpExt = ('_resamp{0}.tif'.format(os.getpid()))
-      resampleFile = outFile.replace(orgExt, tmpExt)
-      gdal.Translate(resampleFile, raster, resampleAlg=resampleMethod,
-          xRes=pixelWidth, yRes=pixelHeight, noData="0")
-      raster = gdal.Open(resampleFile)
+        resampleMethod = GRIORA_Cubic
 
-  # Resample image using cubic interpolation
-  # Save it in the various image formats
-  if outFormat.upper() == 'GEOTIFF':
-    gdal.Translate(outFile, raster, resampleAlg=resampleMethod, width=width)
-  elif outFormat.upper() == 'JPEG' or outFormat.upper() == 'JPG':
-    if colorTable is None:
-      gdal.Translate(outFile, raster, format='JPEG', resampleAlg=resampleMethod,
-        width=width)
-    else:
-      gdal.Translate(outFile, raster, format='JPEG', resampleAlg=resampleMethod,
-        width=width, rgbExpand='RGB')
-  elif outFormat.upper() == 'PNG':
-    if bandCount == 1:
-      gdal.Translate(outFile, raster, format='PNG', resampleAlg=resampleMethod,
-        width=width, noData='0')
-    elif bandCount == 3:
-      gdal.Translate(outFile, raster, format='PNG', resampleAlg=resampleMethod,
-        width=width, noData='0 0 0')
-  elif outFormat.upper() == 'KML':
+    # Suppress GDAL warnings
+    gdal.UseExceptions()
+    gdal.PushErrorHandler('CPLQuietErrorHandler')
 
-    # Reproject to geographic coordinates first
-    tmpExt = ('_geo{0}.tif'.format(os.getpid()))
-    tmpFile = outFile.replace(orgExt, tmpExt)
-    rgbFile = None
-    if bandCount == 1:
-      if colorTable is None:
-        gdal.Warp(tmpFile, raster, resampleAlg=GRIORA_Cubic, width=width,
-          srcNodata='0', dstSRS='EPSG:4326', dstAlpha=True)
-      else:
-        rgbExt = ('_rgb{0}.tif'.format(os.getpid()))
-        rgbFile = outFile.replace(orgExt, rgbExt)
-        gdal.Translate(rgbFile, raster, rgbExpand='RGBA')
-        raster = gdal.Open(rgbFile)
-        gdal.Warp(tmpFile, raster, resampleAlg=GRIORA_Cubic, width=width,
-          srcNodata='0', dstSRS='EPSG:4326', dstAlpha=True)
-    elif bandCount == 3:
-      gdal.Warp(tmpFile, raster, resampleAlg=GRIORA_Cubic, width=width,
-        srcNodata='0 0 0', dstSRS='EPSG:4326', dstAlpha=True)
-    raster = None
+    # Extract information from GeoTIFF
+    raster = gdal.Open(geotiff)
+    bandCount = raster.RasterCount
+    band = raster.GetRasterBand(1)
+    colorTable = band.GetColorTable()
 
-    # Convert GeoTIFF to PNG - since warp cannot do that in one step
-    raster = gdal.Open(tmpFile)
-    pngFile = outFile.replace(orgExt, '.png')
-    gdal.Translate(pngFile, raster, format='PNG', resampleAlg=resampleMethod)
-
-    # Extract metadata from GeoTIFF to fill into the KML
+    # Downsample by multiples of pixel size to avoid interpolation issues
+    # (if needed)
+    orgExt = os.path.splitext(outFile)[1]
+    resampleFile = None
+    resampleFile2 = None
     gt = raster.GetGeoTransform()
-    coordStr = ('%.4f,%.4f %.4f,%.4f %.4f,%.4f %.4f,%.4f' %
-      (gt[0], gt[3]+raster.RasterYSize*gt[5], gt[0]+raster.RasterXSize*gt[1],
-        gt[3]+raster.RasterYSize*gt[5], gt[0]+raster.RasterXSize*gt[1], gt[3],
-        gt[0], gt[3]))
+    cols = raster.RasterXSize
+    # rows = raster.RasterYSize
+    scale = cols / float(width)
+    mult = 2 ** (math.floor(math.log(scale, 2)) - 1)
 
-    # Take care of namespaces
-    prefix = {}
-    gx = '{http://www.google.com/kml/ext/2.2}'
-    prefix['gx'] = gx
-    ns_gx = {'gx' : 'http://www.google.com/kml/ext/2.2'}
-    ns_main = { None : 'http://www.opengis.net/kml/2.2'}
-    ns = dict(list(ns_main.items()) + list(ns_gx.items()))
+    if mult > 1:
+        pixelWidth = gt[1] * mult
+        pixelHeight = gt[5] * mult
+        if outFormat.upper() == 'PNG' and bandCount == 3:
+            tmpExt = '_resamp{0}.png'.format(os.getpid())
+            resampleFile = outFile.replace(orgExt, tmpExt)
+            tmpExt2 = '_resamp2{0}.png'.format(os.getpid())
+            resampleFile2 = outFile.replace(orgExt, tmpExt2)
+            gdal.Translate(resampleFile, raster, format='PNG', noData='0 0 0')
+            gdal.Translate(
+                resampleFile2,
+                resampleFile,
+                resampleAlg=resampleMethod,
+                format='PNG',
+                xRes=pixelWidth,
+                yRes=pixelHeight,
+                noData='0 0 0',
+            )
+            raster = gdal.Open(resampleFile2)
+        else:
+            tmpExt = '_resamp{0}.tif'.format(os.getpid())
+            resampleFile = outFile.replace(orgExt, tmpExt)
+            gdal.Translate(
+                resampleFile, raster, resampleAlg=resampleMethod, xRes=pixelWidth, yRes=pixelHeight, noData='0'
+            )
+            raster = gdal.Open(resampleFile)
 
-    # Fill in the tree structure
-    kmlFile = outFile.replace(orgExt, '.kml')
-    kml = et.Element('kml', nsmap=ns)
-    overlay = et.SubElement(kml, 'GroundOverlay')
-    et.SubElement(overlay, 'name').text = \
-      os.path.basename(kmlFile).replace('.kml', '') + ' overlay'
-    icon = et.SubElement(overlay, 'Icon')
-    et.SubElement(icon, 'href').text = os.path.basename(pngFile)
-    et.SubElement(icon, 'viewBoundScale').text = '0.75'
-    latLonQuad = et.SubElement(overlay, '{0}LatLonQuad'.format(gx))
-    et.SubElement(latLonQuad, 'coordinates').text = coordStr
-    with open(kmlFile, 'wb') as outF:
-      outF.write(et.tostring(kml, xml_declaration=True, encoding='utf-8',
-        pretty_print=True))
+    # Resample image using cubic interpolation
+    # Save it in the various image formats
+    if outFormat.upper() == 'GEOTIFF':
+        gdal.Translate(outFile, raster, resampleAlg=resampleMethod, width=width)
+    elif outFormat.upper() == 'JPEG' or outFormat.upper() == 'JPG':
+        if colorTable is None:
+            gdal.Translate(outFile, raster, format='JPEG', resampleAlg=resampleMethod, width=width)
+        else:
+            gdal.Translate(outFile, raster, format='JPEG', resampleAlg=resampleMethod, width=width, rgbExpand='RGB')
+    elif outFormat.upper() == 'PNG':
+        if bandCount == 1:
+            gdal.Translate(outFile, raster, format='PNG', resampleAlg=resampleMethod, width=width, noData='0')
+        elif bandCount == 3:
+            gdal.Translate(outFile, raster, format='PNG', resampleAlg=resampleMethod, width=width, noData='0 0 0')
+    elif outFormat.upper() == 'KML':
+        # Reproject to geographic coordinates first
+        tmpExt = '_geo{0}.tif'.format(os.getpid())
+        tmpFile = outFile.replace(orgExt, tmpExt)
+        rgbFile = None
+        if bandCount == 1:
+            if colorTable is None:
+                gdal.Warp(
+                    tmpFile,
+                    raster,
+                    resampleAlg=GRIORA_Cubic,
+                    width=width,
+                    srcNodata='0',
+                    dstSRS='EPSG:4326',
+                    dstAlpha=True,
+                )
+            else:
+                rgbExt = '_rgb{0}.tif'.format(os.getpid())
+                rgbFile = outFile.replace(orgExt, rgbExt)
+                gdal.Translate(rgbFile, raster, rgbExpand='RGBA')
+                raster = gdal.Open(rgbFile)
+                gdal.Warp(
+                    tmpFile,
+                    raster,
+                    resampleAlg=GRIORA_Cubic,
+                    width=width,
+                    srcNodata='0',
+                    dstSRS='EPSG:4326',
+                    dstAlpha=True,
+                )
+        elif bandCount == 3:
+            gdal.Warp(
+                tmpFile,
+                raster,
+                resampleAlg=GRIORA_Cubic,
+                width=width,
+                srcNodata='0 0 0',
+                dstSRS='EPSG:4326',
+                dstAlpha=True,
+            )
+        raster = None
 
-    # Zip PNG and KML together - need to be in the directory where the files are
-    # in order to remove any path issues...
-    back = os.getcwd()
-    path = os.path.dirname(outFile)
-    if path  != '':
-        os.chdir(path)
-    zipFile = os.path.basename(outFile.replace(orgExt, '.kmz'))
-    zip = zipfile.ZipFile(zipFile, 'w', zipfile.ZIP_DEFLATED)
-    zip.write(os.path.basename(kmlFile))
-    zip.write(os.path.basename(pngFile))
-    zip.close()
-    os.chdir(back)
+        # Convert GeoTIFF to PNG - since warp cannot do that in one step
+        raster = gdal.Open(tmpFile)
+        pngFile = outFile.replace(orgExt, '.png')
+        gdal.Translate(pngFile, raster, format='PNG', resampleAlg=resampleMethod)
 
-    # Clean up - remove temporary GeoTIFF, KML and PNG
-    os.remove(tmpFile)
-    os.remove(pngFile)
-    os.remove(pngFile + '.aux.xml')
-    os.remove(kmlFile)
-    if rgbFile is not None:
-      os.remove(rgbFile)
+        # Extract metadata from GeoTIFF to fill into the KML
+        gt = raster.GetGeoTransform()
+        coordStr = '%.4f,%.4f %.4f,%.4f %.4f,%.4f %.4f,%.4f' % (
+            gt[0],
+            gt[3] + raster.RasterYSize * gt[5],
+            gt[0] + raster.RasterXSize * gt[1],
+            gt[3] + raster.RasterYSize * gt[5],
+            gt[0] + raster.RasterXSize * gt[1],
+            gt[3],
+            gt[0],
+            gt[3],
+        )
 
-  if resampleFile is not None:
-    for myfile in glob.glob("{0}*".format(resampleFile)):
-      os.remove(myfile)
-    
-  if resampleFile2 is not None:
-    for myfile in glob.glob("{0}*".format(resampleFile2)):
-      os.remove(myfile)
+        # Take care of namespaces
+        prefix = {}
+        gx = '{http://www.google.com/kml/ext/2.2}'
+        prefix['gx'] = gx
+        ns_gx = {'gx': 'http://www.google.com/kml/ext/2.2'}
+        ns_main = {None: 'http://www.opengis.net/kml/2.2'}
+        ns = dict(list(ns_main.items()) + list(ns_gx.items()))
+
+        # Fill in the tree structure
+        kmlFile = outFile.replace(orgExt, '.kml')
+        kml = et.Element('kml', nsmap=ns)
+        overlay = et.SubElement(kml, 'GroundOverlay')
+        et.SubElement(overlay, 'name').text = os.path.basename(kmlFile).replace('.kml', '') + ' overlay'
+        icon = et.SubElement(overlay, 'Icon')
+        et.SubElement(icon, 'href').text = os.path.basename(pngFile)
+        et.SubElement(icon, 'viewBoundScale').text = '0.75'
+        latLonQuad = et.SubElement(overlay, '{0}LatLonQuad'.format(gx))
+        et.SubElement(latLonQuad, 'coordinates').text = coordStr
+        with open(kmlFile, 'wb') as outF:
+            outF.write(et.tostring(kml, xml_declaration=True, encoding='utf-8', pretty_print=True))
+
+        # Zip PNG and KML together - need to be in the directory where the files are
+        # in order to remove any path issues...
+        back = os.getcwd()
+        path = os.path.dirname(outFile)
+        if path != '':
+            os.chdir(path)
+        zipFile = os.path.basename(outFile.replace(orgExt, '.kmz'))
+        zip = zipfile.ZipFile(zipFile, 'w', zipfile.ZIP_DEFLATED)
+        zip.write(os.path.basename(kmlFile))
+        zip.write(os.path.basename(pngFile))
+        zip.close()
+        os.chdir(back)
+
+        # Clean up - remove temporary GeoTIFF, KML and PNG
+        os.remove(tmpFile)
+        os.remove(pngFile)
+        os.remove(pngFile + '.aux.xml')
+        os.remove(kmlFile)
+        if rgbFile is not None:
+            os.remove(rgbFile)
+
+    if resampleFile is not None:
+        for myfile in glob.glob('{0}*'.format(resampleFile)):
+            os.remove(myfile)
+
+    if resampleFile2 is not None:
+        for myfile in glob.glob('{0}*'.format(resampleFile2)):
+            os.remove(myfile)
 
 
 def main():
@@ -190,4 +217,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/src/hyp3lib/rtc2color.py
+++ b/src/hyp3lib/rtc2color.py
@@ -67,8 +67,9 @@ def prepare_geotif_data(geotiff_handle: gdal.Dataset, rows: int, cols: int, amp=
     return data
 
 
-def calculate_color_channel(copol_data: np.ndarray, crosspol_data: np.ndarray, threshold: float,
-                            scale_factor: float, color: str):
+def calculate_color_channel(
+    copol_data: np.ndarray, crosspol_data: np.ndarray, threshold: float, scale_factor: float, color: str
+):
     """Calculate color channel values for the RGB decomposition of copol and crosspol data
 
     Args:
@@ -122,8 +123,16 @@ def calculate_color_channel(copol_data: np.ndarray, crosspol_data: np.ndarray, t
     return color_channel
 
 
-def rtc2color(copol_tif: Union[str, Path], crosspol_tif: Union[str, Path], threshold: float, out_tif: Union[str, Path],
-              cleanup=False, teal=False, amp=False, real=False):
+def rtc2color(
+    copol_tif: Union[str, Path],
+    crosspol_tif: Union[str, Path],
+    threshold: float,
+    out_tif: Union[str, Path],
+    cleanup=False,
+    teal=False,
+    amp=False,
+    real=False,
+):
     """RGB decomposition of a dual-pol RTC
 
     Args:
@@ -202,13 +211,24 @@ def main():
     parser.add_argument('crosspol', help='the cross-pol GeoTIF')
     parser.add_argument('threshold', type=float, help='decomposition threshold value in dB')
     parser.add_argument('geotiff', help='the output color GeoTIFF file name')
-    parser.add_argument('-c', '-cleanup', '--cleanup', action='store_true',
-                        help='cleanup artifacts using a -48 db power threshold')
-    parser.add_argument('-t', '-teal', '--teal', action='store_true',
-                        help='combine green and blue channels because the volume to simple scattering ratio is high')
+    parser.add_argument(
+        '-c', '-cleanup', '--cleanup', action='store_true', help='cleanup artifacts using a -48 db power threshold'
+    )
+    parser.add_argument(
+        '-t',
+        '-teal',
+        '--teal',
+        action='store_true',
+        help='combine green and blue channels because the volume to simple scattering ratio is high',
+    )
     parser.add_argument('-a', '-amp', '--amp', action='store_true', help='input is amplitude, not powerscale')
-    parser.add_argument('-r', '-real', '--real', action='store_true',
-                        help='output real (floating point) values instead of RGB scaled (0--255) ints')
+    parser.add_argument(
+        '-r',
+        '-real',
+        '--real',
+        action='store_true',
+        help='output real (floating point) values instead of RGB scaled (0--255) ints',
+    )
     args = parser.parse_args()
 
     out = logging.StreamHandler(stream=sys.stdout)
@@ -217,8 +237,7 @@ def main():
     err.setLevel(logging.WARNING)
     logging.basicConfig(format='%(message)s', level=logging.INFO, handlers=(out, err))
 
-    rtc2color(args.copol, args.crosspol, args.threshold, args.geotiff,
-              args.cleanup, args.teal, args.amp, args.real)
+    rtc2color(args.copol, args.crosspol, args.threshold, args.geotiff, args.cleanup, args.teal, args.amp, args.real)
 
 
 if __name__ == '__main__':

--- a/src/hyp3lib/saa_func_lib.py
+++ b/src/hyp3lib/saa_func_lib.py
@@ -85,7 +85,7 @@ def getCorners(fi):
 
 def getPixSize(fi):
     (x1, y1, t1, p1) = read_gdal_file_geo(open_gdal_file(fi))
-    return (t1[1])
+    return t1[1]
 
 
 # Get the UTM zone
@@ -99,10 +99,10 @@ def get_zone(lon_min, lon_max):
 def get_utm_proj(lon_min, lon_max, lat_min, lat_max):
     zone = get_zone(lon_min, lon_max)
     if (lat_min + lat_max) / 2 > 0:
-        proj = ('EPSG:326%02d' % int(zone))
+        proj = 'EPSG:326%02d' % int(zone)
     else:
-        proj = ('EPSG:327%02d' % int(zone))
-    print("Found proj {}".format(proj))
+        proj = 'EPSG:327%02d' % int(zone)
+    print('Found proj {}'.format(proj))
     return proj
 
 
@@ -110,8 +110,8 @@ def get_utm_proj(lon_min, lon_max, lat_min, lat_max):
 def reproject_gcs_to_utm(infile, outfile, pixSize):
     lon_min, lon_max, lat_min, lat_max = getCorners(infile)
     proj = get_utm_proj(lon_min, lon_max, lat_min, lat_max)
-    print("Using pixel size {}".format(pixSize))
-    print("Translating {} to make {}".format(infile, outfile))
+    print('Using pixel size {}'.format(pixSize))
+    print('Translating {} to make {}'.format(infile, outfile))
     gdal.Warp(outfile, infile, dstSRS=proj, xRes=pixSize, yRes=pixSize, creationOptions=['COMPRESS=LZW'])
 
 
@@ -129,7 +129,7 @@ def get_corners(originx, originy, xsize, ysize, xres, yres):
 
 
 def open_gdal_file_forscanline(file, x, y, trans, proj, dt='UInt16'):
-    format = "GTiff"
+    format = 'GTiff'
     driver = gdal.GetDriverByName(format)
     if dt == 'UInt16':
         dst_datatype = gdal.GDT_UInt16
@@ -149,7 +149,7 @@ def write_gdal_file_byscanline(driver, xoff, yoff, data, band=1):
 
 def write_gdal_file(filename, geotransform, geoproj, data, gcps='', gcpproj=''):
     (x, y) = data.shape
-    format = "GTiff"
+    format = 'GTiff'
     driver = gdal.GetDriverByName(format)
     dst_datatype = gdal.GDT_Int16
     dst_ds = driver.Create(filename, y, x, 1, dst_datatype)
@@ -171,7 +171,7 @@ def write_gdal_file(filename, geotransform, geoproj, data, gcps='', gcpproj=''):
 
 def write_gdal_file_float(filename, geotransform, geoproj, data, nodata=None):
     (x, y) = data.shape
-    format = "GTiff"
+    format = 'GTiff'
     driver = gdal.GetDriverByName(format)
     dst_datatype = gdal.GDT_Float32
     dst_ds = driver.Create(filename, y, x, 1, dst_datatype)
@@ -193,7 +193,7 @@ def write_gdal_file_float(filename, geotransform, geoproj, data, nodata=None):
 
 def write_gdal_file_byte(filename, geotransform, geoproj, data, nodata=None):
     (x, y) = data.shape
-    format = "GTiff"
+    format = 'GTiff'
     driver = gdal.GetDriverByName(format)
     dst_datatype = gdal.GDT_Byte
     dst_ds = driver.Create(filename, y, x, 1, dst_datatype)
@@ -210,7 +210,7 @@ def write_gdal_file_byte(filename, geotransform, geoproj, data, nodata=None):
 def write_gdal_file_rgb(filename, geotransform, geoproj, b1, b2, b3, metadata=None):
     options = []
     (x, y) = b1.shape
-    format = "GTiff"
+    format = 'GTiff'
     driver = gdal.GetDriverByName(format)
     dst_datatype = gdal.GDT_Byte
     dst_ds = driver.Create(filename, y, x, 3, dst_datatype, options)
@@ -228,7 +228,7 @@ def write_gdal_file_rgb(filename, geotransform, geoproj, b1, b2, b3, metadata=No
 def write_gdal_file_rgba(filename, geotransform, geoproj, b1, b2, b3, b4):
     options = []
     (x, y) = b1.shape
-    format = "GTiff"
+    format = 'GTiff'
     driver = gdal.GetDriverByName(format)
     dst_datatype = gdal.GDT_Byte
     dst_ds = driver.Create(filename, y, x, 4, dst_datatype, options)

--- a/src/hyp3lib/saa_func_lib.py
+++ b/src/hyp3lib/saa_func_lib.py
@@ -29,12 +29,12 @@ def read_gdal_file(filehandle, band=1, gcps=False):
     geoproj = filehandle.GetProjection()
     banddata = filehandle.GetRasterBand(band)
     # type = gdal.GetDataTypeName(banddata.DataType).lower()
-    min = banddata.GetMinimum()
-    max = banddata.GetMaximum()
-    if min is None or max is None:
-        (min, max) = banddata.ComputeRasterMinMax(1)
+    data_min = banddata.GetMinimum()
+    data_max = banddata.GetMaximum()
+    if data_min is None or data_max is None:
+        (data_min, data_max) = banddata.ComputeRasterMinMax(1)
     data = banddata.ReadAsArray()
-    if gcps == False:
+    if gcps is False:
         return filehandle.RasterXSize, filehandle.RasterYSize, geotransform, geoproj, data
     else:
         gcp = filehandle.GetGCPs()
@@ -129,8 +129,8 @@ def get_corners(originx, originy, xsize, ysize, xres, yres):
 
 
 def open_gdal_file_forscanline(file, x, y, trans, proj, dt='UInt16'):
-    format = 'GTiff'
-    driver = gdal.GetDriverByName(format)
+    image_format = 'GTiff'
+    driver = gdal.GetDriverByName(image_format)
     if dt == 'UInt16':
         dst_datatype = gdal.GDT_UInt16
     elif dt == 'Float32':
@@ -149,8 +149,8 @@ def write_gdal_file_byscanline(driver, xoff, yoff, data, band=1):
 
 def write_gdal_file(filename, geotransform, geoproj, data, gcps='', gcpproj=''):
     (x, y) = data.shape
-    format = 'GTiff'
-    driver = gdal.GetDriverByName(format)
+    image_format = 'GTiff'
+    driver = gdal.GetDriverByName(image_format)
     dst_datatype = gdal.GDT_Int16
     dst_ds = driver.Create(filename, y, x, 1, dst_datatype)
     northing = geotransform[0]
@@ -171,8 +171,8 @@ def write_gdal_file(filename, geotransform, geoproj, data, gcps='', gcpproj=''):
 
 def write_gdal_file_float(filename, geotransform, geoproj, data, nodata=None):
     (x, y) = data.shape
-    format = 'GTiff'
-    driver = gdal.GetDriverByName(format)
+    image_format = 'GTiff'
+    driver = gdal.GetDriverByName(image_format)
     dst_datatype = gdal.GDT_Float32
     dst_ds = driver.Create(filename, y, x, 1, dst_datatype)
     northing = geotransform[0]
@@ -193,8 +193,8 @@ def write_gdal_file_float(filename, geotransform, geoproj, data, nodata=None):
 
 def write_gdal_file_byte(filename, geotransform, geoproj, data, nodata=None):
     (x, y) = data.shape
-    format = 'GTiff'
-    driver = gdal.GetDriverByName(format)
+    image_format = 'GTiff'
+    driver = gdal.GetDriverByName(image_format)
     dst_datatype = gdal.GDT_Byte
     dst_ds = driver.Create(filename, y, x, 1, dst_datatype)
     geotransform = [item for item in geotransform]
@@ -210,8 +210,8 @@ def write_gdal_file_byte(filename, geotransform, geoproj, data, nodata=None):
 def write_gdal_file_rgb(filename, geotransform, geoproj, b1, b2, b3, metadata=None):
     options = []
     (x, y) = b1.shape
-    format = 'GTiff'
-    driver = gdal.GetDriverByName(format)
+    image_format = 'GTiff'
+    driver = gdal.GetDriverByName(image_format)
     dst_datatype = gdal.GDT_Byte
     dst_ds = driver.Create(filename, y, x, 3, dst_datatype, options)
     dst_ds.SetGeoTransform(geotransform)
@@ -228,8 +228,8 @@ def write_gdal_file_rgb(filename, geotransform, geoproj, b1, b2, b3, metadata=No
 def write_gdal_file_rgba(filename, geotransform, geoproj, b1, b2, b3, b4):
     options = []
     (x, y) = b1.shape
-    format = 'GTiff'
-    driver = gdal.GetDriverByName(format)
+    image_format = 'GTiff'
+    driver = gdal.GetDriverByName(image_format)
     dst_datatype = gdal.GDT_Byte
     dst_ds = driver.Create(filename, y, x, 4, dst_datatype, options)
     dst_ds.SetGeoTransform(geotransform)

--- a/src/hyp3lib/system.py
+++ b/src/hyp3lib/system.py
@@ -17,7 +17,7 @@ def gamma_version():
             raise
 
         try:
-            with open(f"{gamma_home}/ASF_Gamma_version.txt") as f:
+            with open(f'{gamma_home}/ASF_Gamma_version.txt') as f:
                 gamma_ver = f.readlines()[-1].strip()
         except IOError:
             logging.warning(
@@ -46,7 +46,7 @@ def isce_version():
         raise
 
     # prefer the conda reported version number; requires shell for active conda env
-    version = subprocess.check_output('conda list | grep isce | awk \'{print $2}\'', shell=True, text=True)
+    version = subprocess.check_output("conda list | grep isce | awk '{print $2}'", shell=True, text=True)
     if version:
         return version.strip()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 import os
 import shutil
-import pytest
 from pathlib import Path
+
+import pytest
+
 
 _HERE = os.path.dirname(__file__)
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -38,11 +38,7 @@ def test_upload_file_to_s3(tmp_path, s3_stubber):
     tag_params = {
         'Bucket': 'myBucket',
         'Key': 'myFile.zip',
-        'Tagging': {
-            'TagSet': [
-                {'Key': 'file_type', 'Value': 'product'}
-            ]
-        }
+        'Tagging': {'TagSet': [{'Key': 'file_type', 'Value': 'product'}]},
     }
     s3_stubber.add_response(method='put_object', expected_params=expected_params, service_response={})
     s3_stubber.add_response(method='put_object_tagging', expected_params=tag_params, service_response={})
@@ -62,11 +58,7 @@ def test_upload_file_to_s3_with_prefix(tmp_path, s3_stubber):
     tag_params = {
         'Bucket': 'myBucket',
         'Key': 'myPrefix/myFile.txt',
-        'Tagging': {
-            'TagSet': [
-                {'Key': 'file_type', 'Value': 'product'}
-            ]
-        }
+        'Tagging': {'TagSet': [{'Key': 'file_type', 'Value': 'product'}]},
     }
     s3_stubber.add_response(method='put_object', expected_params=expected_params, service_response={})
     s3_stubber.add_response(method='put_object_tagging', expected_params=tag_params, service_response={})

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -23,8 +23,10 @@ def test_write_credentials_to_netrc_file(tmp_path):
 
     fetch.write_credentials_to_netrc_file('append', 'this', domain='domain', append=True)
     with open(output_file, 'r') as f:
-        assert f.read() == 'machine urs.earthdata.nasa.gov login foo password bar\n' \
-                           'machine domain login append password this\n'
+        assert (
+            f.read() == 'machine urs.earthdata.nasa.gov login foo password bar\n'
+            'machine domain login append password this\n'
+        )
 
 
 def test_get_download_path():
@@ -82,8 +84,9 @@ def test_download_file(safe_data, tmp_path):
 @responses.activate
 def test_download_file_content_disposition(tmp_path):
     responses.add(
-        responses.GET, 'http://hyp3.asf.alaska.edu/foobar.txt',
-        headers={'content-disposition': 'attachment; filename="filename.jpg"'}
+        responses.GET,
+        'http://hyp3.asf.alaska.edu/foobar.txt',
+        headers={'content-disposition': 'attachment; filename="filename.jpg"'},
     )
 
     download_path = fetch.download_file('http://hyp3.asf.alaska.edu/foobar.txt', directory=tmp_path)

--- a/tests/test_get_orb.py
+++ b/tests/test_get_orb.py
@@ -17,10 +17,7 @@ def test_esa_token():
         'username': 'myUsername',
         'password': 'myPassword',
     }
-    response_payload = {
-        'access_token': 'ABC123',
-        'session_state': 'mySessionId'
-    }
+    response_payload = {'access_token': 'ABC123', 'session_state': 'mySessionId'}
     get_request = responses.add(
         responses.POST,
         url=url,
@@ -55,9 +52,9 @@ def test_download_sentinel_orbit_file_esa(tmp_path):
         match=[responses.matchers.header_matcher({'Authorization': 'Bearer test-token'})],
     )
 
-    with patch('hyp3lib.get_orb.get_orbit_url', return_value='https://foo.bar/hello.txt'), \
-            patch('hyp3lib.get_orb.EsaToken.__enter__', return_value='test-token'), \
-            patch('hyp3lib.get_orb.EsaToken.__exit__'):
+    with patch('hyp3lib.get_orb.get_orbit_url', return_value='https://foo.bar/hello.txt'), patch(
+        'hyp3lib.get_orb.EsaToken.__enter__', return_value='test-token'
+    ), patch('hyp3lib.get_orb.EsaToken.__exit__'):
         orbit_file, provider = get_orb.downloadSentinelOrbitFile(
             _GRANULE,
             providers=('ESA',),
@@ -73,12 +70,14 @@ def test_download_sentinel_orbit_file_esa(tmp_path):
 
 @responses.activate
 def test_get_orbit_url_esa_poeorb():
-    search_url = ('https://catalogue.dataspace.copernicus.eu/odata/v1/Products?'
-                  '%24filter=Collection%2FName+eq+%27SENTINEL-1%27+and+'
-                  'startswith%28Name%2C+%27S1A_OPER_AUX_POEORB_OPOD_%27%29+and+'
-                  'ContentDate%2FStart+lt+2015-06-21T12%3A02%3A20Z+and+'
-                  'ContentDate%2FEnd+gt+2015-06-21T12%3A02%3A32Z&'
-                  '%24orderby=Name+desc&%24top=1')
+    search_url = (
+        'https://catalogue.dataspace.copernicus.eu/odata/v1/Products?'
+        '%24filter=Collection%2FName+eq+%27SENTINEL-1%27+and+'
+        'startswith%28Name%2C+%27S1A_OPER_AUX_POEORB_OPOD_%27%29+and+'
+        'ContentDate%2FStart+lt+2015-06-21T12%3A02%3A20Z+and+'
+        'ContentDate%2FEnd+gt+2015-06-21T12%3A02%3A32Z&'
+        '%24orderby=Name+desc&%24top=1'
+    )
     search_response = {'value': [{'Id': 'myProductId'}]}
     responses.add(responses.GET, search_url, json=search_response)
 
@@ -88,12 +87,14 @@ def test_get_orbit_url_esa_poeorb():
 
 @responses.activate
 def test_get_orbit_url_esa_resorb():
-    search_url = ('https://catalogue.dataspace.copernicus.eu/odata/v1/Products?'
-                  '%24filter=Collection%2FName+eq+%27SENTINEL-1%27+and+'
-                  'startswith%28Name%2C+%27S1A_OPER_AUX_RESORB_OPOD_%27%29+and+'
-                  'ContentDate%2FStart+lt+2015-06-21T12%3A02%3A20Z+and+'
-                  'ContentDate%2FEnd+gt+2015-06-21T12%3A02%3A32Z&'
-                  '%24orderby=Name+desc&%24top=1')
+    search_url = (
+        'https://catalogue.dataspace.copernicus.eu/odata/v1/Products?'
+        '%24filter=Collection%2FName+eq+%27SENTINEL-1%27+and+'
+        'startswith%28Name%2C+%27S1A_OPER_AUX_RESORB_OPOD_%27%29+and+'
+        'ContentDate%2FStart+lt+2015-06-21T12%3A02%3A20Z+and+'
+        'ContentDate%2FEnd+gt+2015-06-21T12%3A02%3A32Z&'
+        '%24orderby=Name+desc&%24top=1'
+    )
     search_response = {'value': [{'Id': 'myProductId'}]}
     responses.add(responses.GET, search_url, json=search_response)
 
@@ -104,6 +105,7 @@ def test_get_orbit_url_esa_resorb():
 def test_get_orbit_url_asf():
     orbit_url = get_orb.get_orbit_url(_GRANULE, provider='ASF')
 
-    assert 'https://s1qc.asf.alaska.edu/aux_poeorb/' \
-           'S1A_OPER_AUX_POEORB_OPOD_20150711T121908_V20150620T225944_20150622T005944.EOF' \
-           == orbit_url
+    assert (
+        'https://s1qc.asf.alaska.edu/aux_poeorb/'
+        'S1A_OPER_AUX_POEORB_OPOD_20150711T121908_V20150620T225944_20150622T005944.EOF' == orbit_url
+    )

--- a/tests/test_get_orb.py
+++ b/tests/test_get_orb.py
@@ -5,6 +5,7 @@ import responses
 
 from hyp3lib import get_orb
 
+
 _GRANULE = 'S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8'
 
 

--- a/tests/test_make_asf_browse.py
+++ b/tests/test_make_asf_browse.py
@@ -1,8 +1,8 @@
 import logging
 import os
 
-from osgeo import gdal
 from PIL import Image
+from osgeo import gdal
 
 from hyp3lib.makeAsfBrowse import makeAsfBrowse
 


### PR DESCRIPTION
Changes include:

- Calling `ruff format .` to perform bulk format conversion
- Calling `ruff check --select I --fix .` to fix import orders
- Change all comments to use only a single `#`
- Rename internal variables so that they don't shadow python internal variables
- Add `noqa` statements where fixing formatting could change public interface, or behavior (3 total cases)