### PR TITLE
Update supported Python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Updated formatting using Ruff to pass flake8 check.
 
 ### Remove
+* Support for Python 3.7 and 3.8 has been dropped in line with NumPy and the larger scientific python ecosystem, as described in [NEP-0029](https://numpy.org/neps/nep-0029-deprecation_policy.html) and [SEPC-0000](https://scientific-python.org/specs/spec-0000/)
 * All hyp3lib functionality not currently being used by one of these GitHub orgs: ASFHyP3, asfadmin, ASFOpenSARLab, access-cloud-based-insar, dbekaert, ASFBinderRecipes, or insarlab. For a full list of the deleted files, see [here](https://github.com/ASFHyP3/hyp3-lib/pull/286).
 * Removed now unused dependencies from `pyproject.toml` and `environment.yml`.
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,11 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  - python>=3.9
   - pip
   # For running
   - boto3
   - gdal
-  - importlib_metadata
   - lxml
   - netCDF4
   - numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyp3lib"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 readme = "README.md"
 authors = [
     {name="ASF APD/Tools Team", email="UAF-asf-apd@alaska.edu"},
@@ -17,16 +17,15 @@ classifiers=[
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
     "boto3",
     "gdal",
-    "importlib_metadata",
     "lxml",
     "netCDF4",
     "numpy",

--- a/src/hyp3lib/__init__.py
+++ b/src/hyp3lib/__init__.py
@@ -1,7 +1,6 @@
 """Common library for HyP3 plugins"""
 
-# FIXME: Python 3.8+ this should be `from importlib.metadata...`
-from importlib_metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
 from hyp3lib.exceptions import (
     DemError,
@@ -11,17 +10,7 @@ from hyp3lib.exceptions import (
     OrbitDownloadError,
 )
 
-
-try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
-    print(
-        f'{__name__} package is not installed!\n'
-        f'Install in editable/develop mode via (from the top of this repo):\n'
-        f'   python -m pip install -e .[develop]\n'
-        f'Or, to just get the version number use:\n'
-        f'   python setup.py --version'
-    )
+__version__ = version(__name__)
 
 __all__ = [
     '__version__',


### PR DESCRIPTION
This:
* Drops Python 3.7 and 3.8 support by requiring Python >=3.9
* Explicitly states support for Python 3.11 and 3.12
* removes unecessay `importlib_metada` package as it's now included in the standard library (Python 3.8+) as `importlib.metadata`

Also:
* drops the install warning that's no longer needed now that we've moved to a src directory. 